### PR TITLE
Refactor to use Glaze json library and code cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -580,3 +580,6 @@ scrap/
 
 # Scripts
 scripts/setup_test_db.*
+
+# volumes
+.volumes/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,14 +7,14 @@ check_include_file_cxx(any HAS_ANY)
 check_include_file_cxx(string_view HAS_STRING_VIEW)
 check_include_file_cxx(coroutine HAS_COROUTINE)
 
-set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
 add_executable(${PROJECT_NAME} main.cc)
 
 set_target_properties(${PROJECT_NAME} PROPERTIES
-    CXX_STANDARD 20
+    CXX_STANDARD 23
     CXX_STANDARD_REQUIRED ON
     CXX_EXTENSIONS OFF
     COMPILE_WARNING_AS_ERROR ON
@@ -41,6 +41,9 @@ find_package(jwt-cpp CONFIG REQUIRED)
 find_package(unofficial-argon2 CONFIG REQUIRED)
 find_package(aws-cpp-sdk-core REQUIRED)
 find_package(aws-cpp-sdk-s3 REQUIRED)
+find_package(unordered_dense CONFIG REQUIRED)
+find_package(glaze CONFIG REQUIRED)
+
 
 target_link_libraries(${PROJECT_NAME} PRIVATE Drogon::Drogon 
                                               jwt-cpp::jwt-cpp 
@@ -49,7 +52,9 @@ target_link_libraries(${PROJECT_NAME} PRIVATE Drogon::Drogon
 #                                              redis++::redis++
                                               Boost::uuid
                                               aws-cpp-sdk-core
-                                              aws-cpp-sdk-s3               
+                                              aws-cpp-sdk-s3
+                                              unordered_dense::unordered_dense
+                                              glaze::glaze                
                       )
 
 # ##############################################################################
@@ -94,19 +99,23 @@ target_sources(${PROJECT_NAME}
 # ##############################################################################
 
 # Database management for tests
-# Remove if using docker !!!
-if(WIN32)
-    add_custom_target(setup_test_db
-        COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/scripts/setup_test_db.bat
-        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-        COMMENT "Setting up test database"
-    )
-else()
-    add_custom_target(setup_test_db
-        COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/scripts/setup_test_db.sh
-        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-        COMMENT "Setting up test database"
-    )
-endif()
+# Add if not using docker and Postgres is installed locally !!!
+# if(WIN32)
+#     add_custom_target(setup_test_db
+#         COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/scripts/setup_test_db.bat
+#         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+#         COMMENT "Setting up test database"
+#     )
+# else()
+#     add_custom_target(setup_test_db
+#         COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/scripts/setup_test_db.sh
+#         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+#         COMMENT "Setting up test database"
+#     )
+# endif()
 
-add_subdirectory(test)
+option(ENABLE_TESTS "Enable building tests" ON)
+
+if (ENABLE_TESTS)
+    add_subdirectory(test)
+endif()

--- a/README.MD
+++ b/README.MD
@@ -31,13 +31,15 @@ Install Postgres on your test machine, either [locally](https://www.postgresql.o
 
 Below are some of the dependencies that are used in the project:
 
-- [drogon](https://github.com/drogonframework/drogon) - with some submodules and sub-dependencies like JsonCpp.
-- [argon2](https://github.com/P-H-C/phc-winner-argon2.git)
-- [jwt-cpp](https://github.com/Thalhammer/jwt-cpp)
-- [cppzmq](https://github.com/zeromq/cppzmq) - Pub/Sub, Notification system.
-- ~~[redis-plus-plus](https://github.com/sewenew/redis-plus-plus)~~ - Not currently used or but code stub is present.
-- [boost-uuid](https://www.boost.org/libs/uuid) - Faster UUID than Drogon UUID utility.
-- [aws-sdk-cpp](https://github.com/aws/aws-sdk-cpp) - Only using S3 component for S3 compatible Minio Service.
+* [drogon](https://github.com/drogonframework/drogon) - with some submodules and sub-dependencies like JsonCpp.
+* [argon2](https://github.com/P-H-C/phc-winner-argon2.git)
+* [jwt-cpp](https://github.com/Thalhammer/jwt-cpp)
+* [cppzmq](https://github.com/zeromq/cppzmq) - Pub/Sub, Notification system.
+* ~~[redis-plus-plus](https://github.com/sewenew/redis-plus-plus)~~ - Not currently used or but code stub is present.
+* [boost-uuid](https://www.boost.org/libs/uuid) - Faster UUID than Drogon UUID utility.
+* [aws-sdk-cpp](https://github.com/aws/aws-sdk-cpp) - Only using S3 component for S3 compatible Minio Service.
+* [unordered-dense](https://github.com/martinus/unordered_dense) - Extremely efficient and fast hash map.
+* [Glaze](https://github.com/stephenberry/glaze) - Super fast JSON parsing and serializing with reflection support. (~2.1X faster than JsonCpp)
 
 Installing using vcpkg:
 
@@ -59,11 +61,13 @@ vcpkg install
 ./vcpkg install redis-plus-plus[async,tls,cxx17]:triplet_name  # currently not used, so can be ignored.
 ./vcpkg install boost-uuid:triplet_name
 ./vcpkg install aws-sdk-cpp[s3]:triplet_name
+./vcpkg install unordered-dense:triplet_name
+./vcpkg install glaze:triplet_name
 ```
 
 More information on setting up the drogon-ctl tool can be found [in this guide](https://github.com/drogonframework/drogon/wiki/ENG-02-Installation#Drogon-Installation)
 
-### Compilation
+## Compilation
 
 ```bash
 # Configure CMake
@@ -82,12 +86,46 @@ cmake --build build --config Release --parallel
 cmake --build build --config Release --parallel --clean-first
 ```
 
+## Docker Compose
+
+A [`docker-compose.yml`](./docker-compose.yml) file is provided for running the postgres database, media server services and optionally the main application (uncomment it to enable).
+You can compose up and down the containers using the following commands:
+
+```bash
+# Compose up
+docker compose up -d
+
+# Compose down
+docker compose down
+
+# subsequent runs can be started and stopped using
+docker compose start
+
+docker compose stop
+```
+
+### Media Server
+
+Minio Object Store is used for storing and serving media files. It has an AWS S3 compatible API.
+It is managed in this project using Docker.
+
+#### Credentials
+
+```txt
+MINIO_ROOT_USER=minioadmin
+MINIO_ROOT_PASSWORD=mypassword
+```
+
+If you modify the credentials, make sure to update your created `config.json` and `test_config-sample.json` files.
+
 ### Running the Backend
 
-Modify the configuration files to setup correct backend runtime environment.
+1. Modify the configuration files to setup correct backend runtime environment.
 Create `test_config.json` and `config.json` from the provided sample files: [`config-sample.json`](./config-sample.json) and [`test_config-sample`](./test_config-sample.json).
-
 Fill in the correct details especially the database connection details.
+
+2. Startup the database and media server using docker compose. (You can configure postgres manually if you prefer).
+3. Run application
 
 ```bash
 $ ./buyer-backend.exe --help
@@ -131,15 +169,20 @@ Integration tests using the Drogon built-in test framework.
 
 ### Configure Tests
 
-This can be done once, or whenever the test configuration changes.
+#### Integration tests
 
-Create `setup_test_db.bat` and `setup_test_db.sh` from the provided sample files:  [`setup_test_db-sample.bat`](./scripts/setup_test_db-sample.bat) and [`setup_test_db-sample.sh`](./scripts/setup_test_db-sample.sh).
+Integration tests require the main application to be running and uses services in [`docker-compose.test.yml`](./docker-compose.test.yml).
+Docker automatically create and seeds the DB with provided migration and seed files.
 
-Fill in the correct database connection details.
+> If you are managing Postgres manually, you can do the following to setup the test DB:
+> (Should be done whenever the test configuration changes.)
+> Create `setup_test_db.bat` and `setup_test_db.sh` from the provided sample files [`setup_test_db-sample.bat`](./scripts/setup_test_db-sample.bat) and [`setup_test_db-sample.sh`](./scripts/setup_test_db-sample.sh).
 
-```bash
-cmake --build build --target configure_tests
-```
+> Fill in the correct database connection details.
+
+> ```bash
+> cmake --build build --target configure_tests
+>```
 
 ### Build Tests
 
@@ -154,6 +197,9 @@ cmake --build build --config Debug --target buyer_backend_test
 ### Run Tests
 
 ```bash
+# Setup test docker compose
+docker compose -f docker-compose.test.yml up -d
+
 # Run main application
 ./buyer-backend --test-mode
 
@@ -173,22 +219,25 @@ ctest -C Release -R ChatsTest
 
 # This runs a specific test through the test executable
 ./buyer_backend_test -r ChatsTest
+
+# compose down (remove any associated volume)
+docker compose -f docker-compose.test.yml down -v
 ```
 
 ### Notes for Integration testing
 
-1. Ensure that there no active connection to the PostgreSQL DB before configuring tests. This can cause errors in the setup scripts
-2. Run main application in test mode in separate terminal before running integration tests or else integration tests segfaults.
+1. Run main application in test mode in separate terminal before running integration tests or else integration tests segfaults.
 
    ```bash
-   ./buyer-backend --test-mode 
+   ./buyer-backend --test
    # or
    ./buyer-backend -t
    ```
 
    The test executable makes requests processed by the main application server. Running main server in test mode ensures that it is connected to the correct test database.
+2. If managing postgres manually, ensure that there no active connection to the PostgreSQL DB before configuring tests. This can cause errors in the setup scripts
 
-## Database Management
+## Manual Database Management (Optional) - *Ignore if using Docker*
 
 ### Creating Database
 
@@ -224,42 +273,9 @@ psql -U postgres -d agentbackend -f seeds/001_complete_seed_data.sql
 psql -U postgres -d buyer_app_test -f seeds/001_complete_seed_data.sql
 ```
 
-## Media Server
+> If you are managing postgres manually, you can uncomment the custom targets for setting up the test DB in the [*CMakeLists.txt*](./CMakeLists.txt) and  [*test/CMakeLists.txt*](./test/CMakeLists.txt).
 
-Minio Object Store is used for storing and serving media files. It has an AWS S3 compatible API.
 
-### Installation
-
-```bash
-# Install Minio
-docker run --name minio-media-server -p 9000:9000 -p 9001:9001 -v /c/dev/media_store:/data -e "MINIO_ROOT_USER=minioadmin" -e "MINIO_ROOT_PASSWORD=password" minio/minio server /data --console-address ":9001"
-```
-
-Replace `-v /c/dev/media_store:/data` with the path to the media store directory on your machine for persistent storage.
-If you modify the credentials, make sure to update your created `config.json` and `test_config-sample.json` files.
-
-## Using Docker Compose (Experimental)
-
-A [`docker-compose.yml`](./docker-compose.yml) file is provided for running the postgres database and media server services and optionally, the main application (uncomment it to enable).
-
-> If you are using docker compose, you can remove the custom targets for setting up the test DB.
-
-You can compose up and down the containers using the following commands:
-
-```bash
-# Compose up
-docker compose up -d
-
-# Compose down
-docker compose down
-
-# subsequent runs can be started and stopped using
-docker compose start
-
-docker compose stop
-```
-
-> Note that this is still experimental and may not work as expected.
 
 ## Debugging tips
 
@@ -271,11 +287,11 @@ docker compose stop
 
 * Try to initialize the Json values as much as possible. Especially Array responses.
 
-- Using the `["key"]` accessor in JsonCpp default constructs that field if it doesn't exists, prefer `.isMember("key")` to check for membership.
+* Using the `["key"]` accessor in JsonCpp default constructs that field if it doesn't exists, prefer `.isMember("key")` to check for membership.
 
 * If you want to inspect the Database after a test run, remove the teardown delete queries, recompile and rerun tests. This way you have access to it after a run for more better investigations.
 
-* Use Drogon LOG_INFO and LOG_ERROR macros for logging. For Json responses this helps:
+* Use Drogon LOG_INFO and LOG_ERROR macros for logging. For JsonCpp Json responses this helps:
 
 ```cpp
   LOG_INFO << json_response.toStyledString();

--- a/config-sample.json
+++ b/config-sample.json
@@ -348,6 +348,6 @@
     "jwt_secret": "your_secure_random_production_secret",
     "minio_endpoint": "http://localhost:9000",
     "minio_access_key": "minioadmin",
-    "minio_secret_key": "minioadmin"
+    "minio_secret_key": "mypassword"
   }
 }

--- a/controllers/authentication.cc
+++ b/controllers/authentication.cc
@@ -2,16 +2,6 @@
 
 #include <argon2.h>
 #include <drogon/HttpResponse.h>
-#include <drogon/HttpTypes.h>
-#include <drogon/orm/Criteria.h>
-#include <drogon/orm/DbClient.h>
-#include <drogon/orm/Exception.h>
-#include <drogon/orm/Field.h>
-#include <drogon/orm/Mapper.h>
-#include <drogon/orm/Result.h>
-#include <drogon/orm/ResultIterator.h>
-#include <drogon/orm/Row.h>
-#include <drogon/orm/SqlBinder.h>
 
 #ifndef JWT_DISABLE_PICOJSON
 #define JWT_DISABLE_PICOJSON
@@ -26,11 +16,15 @@
 #include <sstream>
 
 #include "../config/config.hpp"
+#include "../utilities/json_manipulation.hpp"
+#include "../utilities/validation.hpp"
+#include "common_req_n_resp.hpp"
 
 #define ARGON2_HASH_LEN 32
 #define ARGON2_SALT_LEN 16
 
 using drogon::app;
+using drogon::CT_APPLICATION_JSON;
 using drogon::HttpResponse;
 using drogon::k400BadRequest;
 using drogon::k401Unauthorized;
@@ -39,7 +33,6 @@ using drogon::orm::DrogonDbException;
 
 using api::v1::Authentication;
 
-// Helper function to generate a random string for tokens
 std::string generate_random_string(size_t length) {
   const std::string chars =
       "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
@@ -55,7 +48,6 @@ std::string generate_random_string(size_t length) {
   return random_string;
 }
 
-// Helper function for base64 encoding
 std::string base64_encode(std::span<const uint8_t> data) {
   static const char* encoding_table =
       "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
@@ -88,17 +80,14 @@ std::string base64_encode(std::span<const uint8_t> data) {
   return encoded;
 }
 
-// Helper function to generate JWT token
 std::string generate_jwt(int user_id, const std::string& username) {
   const std::string secret = config::JWT_SECRET;
 
-  // Current time and expiration time (1 hour from now)
   auto now = std::chrono::system_clock::now();
   auto exp = now + std::chrono::hours(1);
 
   using traits = jwt::traits::open_source_parsers_jsoncpp;
 
-  // Create JWT token
   auto token =
       jwt::create<traits>()
           .set_issuer("buyer-app")
@@ -112,12 +101,9 @@ std::string generate_jwt(int user_id, const std::string& username) {
   return token;
 }
 
-// Helper function to generate refresh token
 std::string generate_refresh_token() { return generate_random_string(64); }
 
-// Helper function to hash password with Argon2
 std::string hash_password_with_argon2(const std::string& password) {
-  // Generate a random salt
   uint8_t salt[ARGON2_SALT_LEN];
   std::random_device rd;
   std::mt19937 generator(rd());
@@ -127,12 +113,11 @@ std::string hash_password_with_argon2(const std::string& password) {
     salt[i] = static_cast<uint8_t>(distribution(generator));
   }
 
-  // Configure Argon2 parameters
+  // Argon2 parameters
   uint32_t t_cost = 3;        // Number of iterations
   uint32_t m_cost = 1 << 16;  // 64 MiB memory cost
   uint32_t parallelism = 1;   // Number of threads
 
-  // Hash the password
   size_t hash_size =
       argon2_encodedlen(t_cost, m_cost, parallelism, ARGON2_SALT_LEN,
                         ARGON2_HASH_LEN, Argon2_type::Argon2_id);
@@ -151,7 +136,6 @@ std::string hash_password_with_argon2(const std::string& password) {
   return encoded_hash;
 }
 
-// Helper function to verify password with Argon2
 bool verify_password_with_argon2(const std::string& password,
                                  const std::string& hash) {
   // Format: $argon2id$v=19$m=65536,t=3,p=1$<salt>$<hash>
@@ -162,12 +146,46 @@ bool verify_password_with_argon2(const std::string& password,
   return result == ARGON2_OK;
 }
 
+struct LoginCredentials {
+  std::string username;
+  std::string password;
+};
+
+struct CredentialsResponse {
+  std::string status;
+  std::string token;
+  std::string refresh_token;
+  int user_id;
+  std::string username;
+};
+
+struct RefreshRequest {
+  std::string refresh_token;
+};
+
+struct RegisterRequest {
+  std::string username;
+  std::string email;
+  std::string password;
+};
+
 drogon::Task<> Authentication::login(
     const drogon::HttpRequestPtr req,
     std::function<void(const drogon::HttpResponsePtr&)> callback) {
-  auto json = req->getJsonObject();
-  std::string username = (*json)["username"].asString();
-  std::string password = (*json)["password"].asString();
+  auto body = req->getBody();
+  LoginCredentials creds;
+  auto parse_error = utilities::strict_read_json(creds, body);
+
+  if (parse_error || creds.username.empty() || creds.password.empty()) {
+    LOG_WARN << "Wrong credentials schema";
+    SimpleError ret{.error =
+                        "Invalid request, requires valid username & password"};
+    auto resp =
+        HttpResponse::newHttpResponse(k400BadRequest, CT_APPLICATION_JSON);
+    resp->setBody(glz::write_json(ret).value_or(""));
+    callback(resp);
+    co_return;
+  }
 
   // for debugging hashes
   // LOG_INFO << "Password hash:" << hash_password_with_argon2(password) <<
@@ -177,80 +195,75 @@ drogon::Task<> Authentication::login(
   try {
     auto result = co_await db->execSqlCoro(
         "SELECT id, username, password_hash FROM users WHERE username = $1",
-        username);
+        creds.username);
 
-    if (!result.empty()) {
-      const auto& row = result[0];
-      int user_id = row["id"].as<int>();
-      std::string stored_hash = row["password_hash"].as<std::string>();
-
-      // Verify password using Argon2
-      bool password_match = verify_password_with_argon2(password, stored_hash);
-
-      if (!password_match) {
-        // Password doesn't match
-        Json::Value ret;
-        ret["status"] = "failure";
-        ret["message"] = "Invalid username or password";
-        auto resp = HttpResponse::newHttpJsonResponse(ret);
-        resp->setStatusCode(k401Unauthorized);
-        callback(resp);
-      }
-
-      // Generate JWT token
-      std::string token = generate_jwt(user_id, username);
-
-      // Generate refresh token
-      std::string refresh_token = generate_refresh_token();
-
-      // Store refresh token in database
-      auto expiry = std::chrono::system_clock::now() +
-                    std::chrono::hours(24 * 7);  // 1 week
-      auto expiry_time = std::chrono::system_clock::to_time_t(expiry);
-
-      try {
-        co_await db->execSqlCoro(
-            "INSERT INTO user_sessions (user_id, token, refresh_token, "
-            "expires_at) VALUES ($1, $2, $3, to_timestamp($4)) "
-            "ON CONFLICT (token) DO NOTHING",
-            user_id, token, refresh_token, static_cast<double>(expiry_time));
-
-        // Return success with tokens
-        Json::Value ret;
-        ret["status"] = "success";
-        ret["token"] = token;
-        ret["refresh_token"] = refresh_token;
-        ret["user_id"] = user_id;
-        ret["username"] = username;
-
-        auto resp = HttpResponse::newHttpJsonResponse(ret);
-        callback(resp);
-      } catch (const DrogonDbException& e) {
-        LOG_ERROR << "Failed to store session: " << e.base().what();
-        Json::Value ret;
-        ret["status"] = "failure";
-        ret["message"] = "An error occurred";
-        auto resp = HttpResponse::newHttpJsonResponse(ret);
-        resp->setStatusCode(k500InternalServerError);
-        callback(resp);
-      }
-    } else {
-      // User not found
-      Json::Value ret;
-      ret["status"] = "failure";
-      ret["message"] = "Invalid username or password";
-      auto resp = HttpResponse::newHttpJsonResponse(ret);
-      resp->setStatusCode(k401Unauthorized);
+    if (result.empty()) {
+      SimpleError ret{.error = "Invalid username/password"};
+      auto resp =
+          HttpResponse::newHttpResponse(k401Unauthorized, CT_APPLICATION_JSON);
+      resp->setBody(glz::write_json(ret).value_or(""));
       callback(resp);
+      co_return;
+    }
+    const auto& row = result[0];
+    int user_id = row["id"].as<int>();
+    std::string stored_hash = row["password_hash"].as<std::string>();
+
+    bool password_match =
+        verify_password_with_argon2(creds.password, stored_hash);
+
+    if (!password_match) {
+      SimpleError ret{.error = "Invalid username/password"};
+      auto resp =
+          HttpResponse::newHttpResponse(k401Unauthorized, CT_APPLICATION_JSON);
+      resp->setBody(glz::write_json(ret).value_or(""));
+      callback(resp);
+      co_return;
+    }
+
+    std::string token = generate_jwt(user_id, creds.username);
+
+    std::string refresh_token = generate_refresh_token();
+
+    auto expiry = std::chrono::system_clock::now() +
+                  std::chrono::hours(24 * 7);  // 1 week
+    auto expiry_time = std::chrono::system_clock::to_time_t(expiry);
+
+    try {
+      co_await db->execSqlCoro(
+          "INSERT INTO user_sessions (user_id, token, refresh_token, "
+          "expires_at) VALUES ($1, $2, $3, to_timestamp($4)) "
+          "ON CONFLICT (token) DO NOTHING",
+          user_id, token, refresh_token, static_cast<double>(expiry_time));
+
+      CredentialsResponse response{.status = "success",
+                                   .token = token,
+                                   .refresh_token = refresh_token,
+                                   .user_id = user_id,
+                                   .username = creds.username};
+
+      auto resp =
+          HttpResponse::newHttpResponse(drogon::k200OK, CT_APPLICATION_JSON);
+      resp->setBody(glz::write_json(response).value_or(""));
+      callback(resp);
+      co_return;
+    } catch (const DrogonDbException& e) {
+      LOG_ERROR << "Failed to store session: " << e.base().what();
+      SimpleError ret{.error = "An error occurred"};
+      auto resp = HttpResponse::newHttpResponse(k500InternalServerError,
+                                                CT_APPLICATION_JSON);
+      resp->setBody(glz::write_json(ret).value_or(""));
+      callback(resp);
+      co_return;
     }
   } catch (const DrogonDbException& e) {
     LOG_ERROR << "Database error: " << e.base().what();
-    Json::Value ret;
-    ret["status"] = "failure";
-    ret["message"] = "An error occurred";
-    auto resp = HttpResponse::newHttpJsonResponse(ret);
-    resp->setStatusCode(k500InternalServerError);
+    SimpleError ret{.error = "An error occurred"};
+    auto resp = HttpResponse::newHttpResponse(k500InternalServerError,
+                                              CT_APPLICATION_JSON);
+    resp->setBody(glz::write_json(ret).value_or(""));
     callback(resp);
+    co_return;
   }
 
   co_return;
@@ -259,37 +272,35 @@ drogon::Task<> Authentication::login(
 drogon::Task<> Authentication::logout(
     const drogon::HttpRequestPtr req,
     std::function<void(const drogon::HttpResponsePtr&)> callback) {
-  // Get the token from the Authorization header
   const std::string& auth_header = req->getHeader("Authorization");
 
   if (!auth_header.empty() && auth_header.substr(0, 7) == "Bearer ") {
     std::string token = auth_header.substr(7);
 
-    // Remove the session from the database
     auto db = app().getDbClient();
     try {
       co_await db->execSqlCoro("DELETE FROM user_sessions WHERE token = $1",
                                token);
 
-      Json::Value ret;
-      ret["status"] = "success";
-      auto resp = HttpResponse::newHttpJsonResponse(ret);
+      SimpleStatus ret{.status = "success"};
+      auto resp =
+          HttpResponse::newHttpResponse(drogon::k200OK, CT_APPLICATION_JSON);
+      resp->setBody(glz::write_json(ret).value_or(""));
       callback(resp);
     } catch (const DrogonDbException& e) {
       LOG_ERROR << "Database error: " << e.base().what();
-      Json::Value ret;
-      ret["status"] = "failure";
-      ret["message"] = "An error occurred";
-      auto resp = HttpResponse::newHttpJsonResponse(ret);
-      resp->setStatusCode(k500InternalServerError);
+      SimpleError ret{.error = "An error occurred"};
+      auto resp = HttpResponse::newHttpResponse(k500InternalServerError,
+                                                CT_APPLICATION_JSON);
+      resp->setBody(glz::write_json(ret).value_or(""));
       callback(resp);
     }
   } else {
-    // No token provided
-    Json::Value ret;
-    ret["status"] = "success";  // Still return success as the user is
-                                // effectively logged out
-    auto resp = HttpResponse::newHttpJsonResponse(ret);
+    SimpleStatus ret{.status = "success"};  // Still return success as the user
+                                            // is effectively logged out
+    auto resp =
+        HttpResponse::newHttpResponse(drogon::k200OK, CT_APPLICATION_JSON);
+    resp->setBody(glz::write_json(ret).value_or(""));
     callback(resp);
   }
 
@@ -299,15 +310,14 @@ drogon::Task<> Authentication::logout(
 drogon::Task<> Authentication::refresh(
     const drogon::HttpRequestPtr req,
     std::function<void(const drogon::HttpResponsePtr&)> callback) {
-  auto json = req->getJsonObject();
-  std::string refresh_token = (*json)["refresh_token"].asString();
+  RefreshRequest refresh_req;
+  auto parse_error = utilities::strict_read_json(refresh_req, req->getBody());
 
-  if (refresh_token.empty()) {
-    Json::Value ret;
-    ret["status"] = "failure";
-    ret["message"] = "Refresh token is required";
-    auto resp = HttpResponse::newHttpJsonResponse(ret);
-    resp->setStatusCode(k400BadRequest);
+  if (parse_error || refresh_req.refresh_token.empty()) {
+    SimpleError ret{.error = "Refresh token is required"};
+    auto resp =
+        HttpResponse::newHttpResponse(k400BadRequest, CT_APPLICATION_JSON);
+    resp->setBody(glz::write_json(ret).value_or(""));
     callback(resp);
     co_return;
   }
@@ -317,22 +327,19 @@ drogon::Task<> Authentication::refresh(
     auto result = co_await db->execSqlCoro(
         "SELECT user_id, expires_at FROM user_sessions WHERE refresh_token ="
         "$1",
-        refresh_token);
+        refresh_req.refresh_token);
 
     if (result.empty()) {
-      // Refresh token not found
-      Json::Value ret;
-      ret["status"] = "failure";
-      ret["message"] = "Invalid refresh token";
-      auto resp = HttpResponse::newHttpJsonResponse(ret);
-      resp->setStatusCode(k401Unauthorized);
+      SimpleError ret{.error = "Invalid refresh token"};
+      auto resp =
+          HttpResponse::newHttpResponse(k401Unauthorized, CT_APPLICATION_JSON);
+      resp->setBody(glz::write_json(ret).value_or(""));
       callback(resp);
       co_return;
     }
     const auto& row = result[0];
     int user_id = row["user_id"].as<int>();
 
-    // Check if refresh token has expired
     auto expiry_str = row["expires_at"].as<std::string>();
 
     // Parse timestamp from PostgreSQL format (e.g., "2025-04-25 12:34:56")
@@ -343,11 +350,10 @@ drogon::Task<> Authentication::refresh(
     ss >> std::chrono::parse("%Y-%m-%d %H:%M:%S", expiry_time_point);
     if (ss.fail()) {
       LOG_ERROR << "Failed to parse expiry time: " << expiry_str;
-      Json::Value ret;
-      ret["status"] = "failure";
-      ret["message"] = "An error occurred";
-      auto resp = HttpResponse::newHttpJsonResponse(ret);
-      resp->setStatusCode(k500InternalServerError);
+      SimpleError ret{.error = "An error occurred"};
+      auto resp = HttpResponse::newHttpResponse(k500InternalServerError,
+                                                CT_APPLICATION_JSON);
+      resp->setBody(glz::write_json(ret).value_or(""));
       callback(resp);
       co_return;
     }
@@ -358,14 +364,12 @@ drogon::Task<> Authentication::refresh(
 
     auto now = std::chrono::system_clock::now();
 
-    // Check if token has expired
     if (expiry_time_point < now) {
       LOG_INFO << "Refresh token has expired";
-      Json::Value ret;
-      ret["status"] = "failure";
-      ret["message"] = "Refresh token has expired";
-      auto resp = HttpResponse::newHttpJsonResponse(ret);
-      resp->setStatusCode(k401Unauthorized);
+      SimpleError ret{.error = "Refresh token has expired"};
+      auto resp =
+          HttpResponse::newHttpResponse(k401Unauthorized, CT_APPLICATION_JSON);
+      resp->setBody(glz::write_json(ret).value_or(""));
       callback(resp);
       co_return;
     }
@@ -377,26 +381,21 @@ drogon::Task<> Authentication::refresh(
           "SELECT username FROM users WHERE id = $1", user_id);
 
       if (user_result.empty()) {
-        // User not found
-        Json::Value ret;
-        ret["status"] = "failure";
-        ret["message"] = "Invalid refresh token";
-        auto resp = HttpResponse::newHttpJsonResponse(ret);
-        resp->setStatusCode(k401Unauthorized);
+        SimpleError ret{.error = "Invalid refresh token"};
+        auto resp = HttpResponse::newHttpResponse(k401Unauthorized,
+                                                  CT_APPLICATION_JSON);
+        resp->setBody(glz::write_json(ret).value_or(""));
         callback(resp);
         co_return;
       }
       std::string username = user_result[0]["username"].as<std::string>();
 
-      // Generate new JWT token
       std::string new_token = generate_jwt(user_id, username);
 
-      // Generate new refresh token
       std::string new_refresh_token = generate_refresh_token();
 
-      // Update session in database
-      auto expiry = std::chrono::system_clock::now() +
-                    std::chrono::hours(24 * 7);  // 1 week
+      auto expiry =
+          std::chrono::system_clock::now() + std::chrono::hours(24 * 7);
       auto expiry_time = std::chrono::system_clock::to_time_t(expiry);
 
       try {
@@ -404,45 +403,42 @@ drogon::Task<> Authentication::refresh(
             "UPDATE user_sessions SET token = $1, refresh_token = "
             "$2, expires_at = to_timestamp($3) WHERE refresh_token = $4",
             new_token, new_refresh_token, static_cast<double>(expiry_time),
-            refresh_token);
+            refresh_req.refresh_token);
 
-        // Return success with new tokens
-        Json::Value ret;
-        ret["status"] = "success";
-        ret["token"] = new_token;
-        ret["refresh_token"] = new_refresh_token;
-        ret["user_id"] = user_id;
-        ret["username"] = username;
+        CredentialsResponse response{.status = "success",
+                                     .token = new_token,
+                                     .refresh_token = new_refresh_token,
+                                     .user_id = user_id,
+                                     .username = username};
 
-        auto resp = HttpResponse::newHttpJsonResponse(ret);
+        auto resp =
+            HttpResponse::newHttpResponse(drogon::k200OK, CT_APPLICATION_JSON);
+        resp->setBody(glz::write_json(response).value_or(""));
         callback(resp);
       } catch (const DrogonDbException& e) {
         LOG_ERROR << "Failed to update session: " << e.base().what();
-        Json::Value ret;
-        ret["status"] = "failure";
-        ret["message"] = "An error occurred";
-        auto resp = HttpResponse::newHttpJsonResponse(ret);
-        resp->setStatusCode(k500InternalServerError);
+        SimpleError ret{.error = "An error occurred"};
+        auto resp = HttpResponse::newHttpResponse(k500InternalServerError,
+                                                  CT_APPLICATION_JSON);
+        resp->setBody(glz::write_json(ret).value_or(""));
         callback(resp);
       }
 
     } catch (const DrogonDbException& e) {
       LOG_ERROR << "Database error: " << e.base().what();
-      Json::Value ret;
-      ret["status"] = "failure";
-      ret["message"] = "An error occurred";
-      auto resp = HttpResponse::newHttpJsonResponse(ret);
-      resp->setStatusCode(k500InternalServerError);
+      SimpleError ret{.error = "An error occurred"};
+      auto resp = HttpResponse::newHttpResponse(k500InternalServerError,
+                                                CT_APPLICATION_JSON);
+      resp->setBody(glz::write_json(ret).value_or(""));
       callback(resp);
     }
 
   } catch (const DrogonDbException& e) {
     LOG_ERROR << "Database error: " << e.base().what();
-    Json::Value ret;
-    ret["status"] = "failure";
-    ret["message"] = "An error occurred";
-    auto resp = HttpResponse::newHttpJsonResponse(ret);
-    resp->setStatusCode(k500InternalServerError);
+    SimpleError ret{.error = "An error occurred"};
+    auto resp = HttpResponse::newHttpResponse(k500InternalServerError,
+                                              CT_APPLICATION_JSON);
+    resp->setBody(glz::write_json(ret).value_or(""));
     callback(resp);
   }
 
@@ -452,33 +448,29 @@ drogon::Task<> Authentication::refresh(
 drogon::Task<> Authentication::register_user(
     const drogon::HttpRequestPtr req,
     std::function<void(const drogon::HttpResponsePtr&)> callback) {
-  auto json = req->getJsonObject();
-  std::string username = (*json)["username"].asString();
-  std::string email = (*json)["email"].asString();
-  std::string password = (*json)["password"].asString();
+  RegisterRequest register_req;
+  auto parse_error = utilities::strict_read_json(register_req, req->getBody());
 
-  // Validate input
-  if (username.empty() || email.empty() || password.empty()) {
-    Json::Value ret;
-    ret["status"] = "failure";
-    ret["message"] = "Username, email, and password are required";
-    auto resp = HttpResponse::newHttpJsonResponse(ret);
-    resp->setStatusCode(k400BadRequest);
+  if (parse_error || register_req.username.empty() ||
+      utilities::is_email_valid(register_req.email) ||
+      register_req.password.empty()) {
+    SimpleError ret{.error = "Username, email, and password are required"};
+    auto resp =
+        HttpResponse::newHttpResponse(k400BadRequest, CT_APPLICATION_JSON);
+    resp->setBody(glz::write_json(ret).value_or(""));
     callback(resp);
     co_return;
   }
 
-  // Hash password with Argon2
   std::string password_hash;
   try {
-    password_hash = hash_password_with_argon2(password);
+    password_hash = hash_password_with_argon2(register_req.password);
   } catch (const std::exception& e) {
     LOG_ERROR << "Failed to hash password: " << e.what();
-    Json::Value ret;
-    ret["status"] = "failure";
-    ret["message"] = "An error occurred during registration";
-    auto resp = HttpResponse::newHttpJsonResponse(ret);
-    resp->setStatusCode(k500InternalServerError);
+    SimpleError ret{.error = "An error occurred during registration"};
+    auto resp = HttpResponse::newHttpResponse(k500InternalServerError,
+                                              CT_APPLICATION_JSON);
+    resp->setBody(glz::write_json(ret).value_or(""));
     callback(resp);
     co_return;
   }
@@ -486,48 +478,39 @@ drogon::Task<> Authentication::register_user(
   auto db = app().getDbClient();
 
   try {
-    // Check if username or email already exists
     auto result = co_await db->execSqlCoro(
-        "SELECT id FROM users WHERE username = $1 OR email = $2", username,
-        email);
+        "SELECT id FROM users WHERE username = $1 OR email = $2",
+        register_req.username, register_req.email);
 
     if (!result.empty()) {
-      // Username or email already exists
-      Json::Value ret;
-      ret["status"] = "failure";
-      ret["message"] = "Username or email already exists";
-      auto resp = HttpResponse::newHttpJsonResponse(ret);
-      resp->setStatusCode(drogon::k409Conflict);
+      SimpleError ret{.error = "Username or email already exists"};
+      auto resp = HttpResponse::newHttpResponse(drogon::k409Conflict,
+                                                CT_APPLICATION_JSON);
+      resp->setBody(glz::write_json(ret).value_or(""));
       callback(resp);
       co_return;
     } else {
-      // Create new user
       try {
         auto insert_result = co_await db->execSqlCoro(
             "INSERT INTO users (username, email, password_hash) VALUES ($1, "
             "$2, $3) RETURNING id",
-            username, email, password_hash);
+            register_req.username, register_req.email, password_hash);
 
         if (insert_result.empty()) {
-          // Failed to insert user
-          Json::Value ret;
-          ret["status"] = "failure";
-          ret["message"] = "Failed to create user";
-          auto resp = HttpResponse::newHttpJsonResponse(ret);
-          resp->setStatusCode(k500InternalServerError);
+          SimpleError ret{.error = "Failed to create user"};
+          auto resp = HttpResponse::newHttpResponse(k500InternalServerError,
+                                                    CT_APPLICATION_JSON);
+          resp->setBody(glz::write_json(ret).value_or(""));
           callback(resp);
           co_return;
         }
         int user_id = insert_result[0]["id"].as<int>();
 
-        // Generate JWT token
-        std::string token = generate_jwt(user_id, username);
+        std::string token = generate_jwt(user_id, register_req.username);
 
-        // Generate refresh token
         std::string refresh_token = generate_refresh_token();
-        // Store refresh token in database
-        auto expiry = std::chrono::system_clock::now() +
-                      std::chrono::hours(24 * 7);  // 1 week
+        auto expiry =
+            std::chrono::system_clock::now() + std::chrono::hours(24 * 7);
         auto expiry_time = std::chrono::system_clock::to_time_t(expiry);
 
         try {
@@ -537,43 +520,41 @@ drogon::Task<> Authentication::register_user(
               "ON CONFLICT (token) DO NOTHING",
               user_id, token, refresh_token, static_cast<double>(expiry_time));
 
-          // Return success with tokens
-          Json::Value ret;
-          ret["status"] = "success";
-          ret["token"] = token;
-          ret["refresh_token"] = refresh_token;
-          ret["user_id"] = user_id;
-          ret["username"] = username;
+          CredentialsResponse response{.status = "success",
+                                       .token = token,
+                                       .refresh_token = refresh_token,
+                                       .user_id = user_id,
+                                       .username = register_req.username};
 
-          auto resp = HttpResponse::newHttpJsonResponse(ret);
+          auto resp = HttpResponse::newHttpResponse(drogon::k200OK,
+                                                    CT_APPLICATION_JSON);
+          resp->setBody(glz::write_json(response).value_or(""));
           callback(resp);
         } catch (const DrogonDbException& e) {
           LOG_ERROR << "Failed to store session: " << e.base().what();
-          Json::Value ret;
-          ret["status"] = "failure";
-          ret["message"] = "Registration successful, but failed to log in";
-          auto resp = HttpResponse::newHttpJsonResponse(ret);
-          resp->setStatusCode(k500InternalServerError);
+          SimpleError ret{.error =
+                              "Registration successful, but failed to log in"};
+          auto resp = HttpResponse::newHttpResponse(k500InternalServerError,
+                                                    CT_APPLICATION_JSON);
+          resp->setBody(glz::write_json(ret).value_or(""));
           callback(resp);
         }
 
       } catch (const DrogonDbException& e) {
         LOG_ERROR << "Database error: " << e.base().what();
-        Json::Value ret;
-        ret["status"] = "failure";
-        ret["message"] = "An error occurred during registration";
-        auto resp = HttpResponse::newHttpJsonResponse(ret);
-        resp->setStatusCode(k500InternalServerError);
+        SimpleError ret{.error = "An error occurred during registration"};
+        auto resp = HttpResponse::newHttpResponse(k500InternalServerError,
+                                                  CT_APPLICATION_JSON);
+        resp->setBody(glz::write_json(ret).value_or(""));
         callback(resp);
       }
     }
   } catch (const DrogonDbException& e) {
     LOG_ERROR << "Database error: " << e.base().what();
-    Json::Value ret;
-    ret["status"] = "failure";
-    ret["message"] = "An error occurred during registration";
-    auto resp = HttpResponse::newHttpJsonResponse(ret);
-    resp->setStatusCode(k500InternalServerError);
+    SimpleError ret{.error = "An error occurred during registration"};
+    auto resp = HttpResponse::newHttpResponse(k500InternalServerError,
+                                              CT_APPLICATION_JSON);
+    resp->setBody(glz::write_json(ret).value_or(""));
     callback(resp);
   }
 

--- a/controllers/authentication.cc
+++ b/controllers/authentication.cc
@@ -452,7 +452,7 @@ drogon::Task<> Authentication::register_user(
   auto parse_error = utilities::strict_read_json(register_req, req->getBody());
 
   if (parse_error || register_req.username.empty() ||
-      utilities::is_email_valid(register_req.email) ||
+      !utilities::is_email_valid(register_req.email) ||
       register_req.password.empty()) {
     SimpleError ret{.error = "Username, email, and password are required"};
     auto resp =

--- a/controllers/authentication.hpp
+++ b/controllers/authentication.hpp
@@ -1,6 +1,5 @@
 #pragma once
 #include <drogon/HttpController.h>
-#include <drogon/orm/DbClient.h>
 
 namespace api {
 

--- a/controllers/chats.cc
+++ b/controllers/chats.cc
@@ -16,12 +16,16 @@
 
 #include "../services/service_manager.hpp"
 #include "../utilities/conversion.hpp"
+#include "../utilities/json_manipulation.hpp"
+#include "common_req_n_resp.hpp"
 #include "scenario_specific_utils.hpp"
 
 using drogon::app;
+using drogon::CT_APPLICATION_JSON;
 using drogon::HttpRequestPtr;
 using drogon::HttpResponse;
 using drogon::HttpResponsePtr;
+using drogon::k200OK;
 using drogon::k400BadRequest;
 using drogon::k401Unauthorized;
 using drogon::k403Forbidden;
@@ -32,6 +36,65 @@ using drogon::Task;
 using drogon::orm::DrogonDbException;
 
 using api::v1::Chats;
+
+struct Conversation {
+  int id;
+  std::string name;
+  std::string other_username;
+  std::string lastMessage;
+  std::string modified_at;
+};
+
+struct CreateConversationRequest {
+  std::string name;
+  int user_id;
+};
+
+struct CreateConversationResponse {
+  std::string status;
+  int conversation_id;
+  std::string message;
+};
+
+struct Message {
+  int id;
+  int sender_id;
+  std::string sender_name;
+  std::string content;
+  std::string message_type;
+  bool is_read;
+  std::string created_at;
+  std::string metadata;  // json content
+  std::optional<std::vector<MediaQuickInfo>> media;
+};
+
+struct SendMessageRequest {
+  std::optional<std::string> content;
+  std::optional<std::vector<std::string>> media;
+};
+
+struct SendMessageResponse {
+  std::string status;
+  int message_id;
+  std::string created_at;
+  std::string message_type;
+  std::optional<std::vector<MediaQuickInfo>> media;
+};
+
+struct GetConversationByOfferResponse {
+  std::string status;
+  int conversation_id;
+  bool is_new;
+};
+
+struct MarkMessagesAsReadResponse {
+  std::string status;
+  int messages_marked;
+};
+
+struct UnreadCountResponse {
+  int unread_count;
+};
 
 Task<> Chats::get_conversations(
     HttpRequestPtr req, std::function<void(const HttpResponsePtr&)> callback) {
@@ -61,27 +124,28 @@ Task<> Chats::get_conversations(
         ") m ON m.conversation_id = c.id AND m.rn = 1 "
         "WHERE cp.user_id = $1 "
         "ORDER BY last_message_time DESC",
-        std::stoi(user_id));
+        convert::string_to_int(user_id).value());
 
-    Json::Value conversations;
+    std::vector<Conversation> data;
+    data.reserve(result.size());
     for (const auto& row : result) {
-      Json::Value conversation;
-      conversation["id"] = row["id"].as<int>();
-      conversation["name"] = row["name"].as<std::string>();
-      conversation["other_username"] = row["other_username"].as<std::string>();
-      conversation["lastMessage"] = row["last_message"].as<std::string>();
-      conversation["created_at"] = row["created_at"].as<std::string>();
-      conversations.append(conversation);
+      data.emplace_back(Conversation{
+          .id = row["id"].as<int>(),
+          .name = row["name"].as<std::string>(),
+          .other_username = row["other_username"].as<std::string>(),
+          .lastMessage = row["last_message"].as<std::string>(),
+          .modified_at = row["created_at"].as<std::string>()});
     }
 
-    auto resp = HttpResponse::newHttpJsonResponse(conversations);
+    auto resp = HttpResponse::newHttpResponse(k200OK, CT_APPLICATION_JSON);
+    resp->setBody(glz::write_json(data).value_or(""));
     callback(resp);
   } catch (const DrogonDbException& e) {
     LOG_ERROR << "Database error: " << e.base().what();
-    Json::Value error;
-    error["error"] = "Database error";
-    auto resp = HttpResponse::newHttpJsonResponse(error);
-    resp->setStatusCode(k500InternalServerError);
+    SimpleError ret{.error = "Database error"};
+    auto resp = HttpResponse::newHttpResponse(k500InternalServerError,
+                                              CT_APPLICATION_JSON);
+    resp->setBody(glz::write_json(ret).value_or(""));
     callback(resp);
   }
 
@@ -90,29 +154,29 @@ Task<> Chats::get_conversations(
 
 Task<> Chats::create_conversation(
     HttpRequestPtr req, std::function<void(const HttpResponsePtr&)> callback) {
-  auto json = req->getJsonObject();
-  std::string user_id =
-      req->getAttributes()->get<std::string>("current_user_id");
+  auto body = req->getBody();
+  CreateConversationRequest create_conv_req;
+  auto parse_error = utilities::strict_read_json(create_conv_req, body);
 
-  // Validation: Ensure name and user_id are provided
-  if (!json || !(*json).isMember("name") || !(*json).isMember("user_id") ||
-      (*json)["name"].asString().empty() || (*json)["user_id"].asInt() < 0) {
-    Json::Value error;
-    error["error"] = "Valid user_id and name required";
-    auto resp = HttpResponse::newHttpJsonResponse(error);
-    resp->setStatusCode(k400BadRequest);
+  if (parse_error || create_conv_req.name.empty() ||
+      create_conv_req.user_id < 0) {
+    LOG_INFO << "Validation failed for create_conversation";
+    SimpleError ret{.error = "Valid user_id and name required"};
+    auto resp =
+        HttpResponse::newHttpResponse(k400BadRequest, CT_APPLICATION_JSON);
+    resp->setBody(glz::write_json(ret).value_or(""));
     callback(resp);
     co_return;
   }
 
-  LOG_INFO << "Does user_id exist? : " << (*json).isMember("user_id");
-  int other_user_id = (*json)["user_id"].asInt();
-  std::string name = (*json)["name"].asString();
+  int other_user_id = create_conv_req.user_id;
+  std::string name = create_conv_req.name;
+  std::string user_id =
+      req->getAttributes()->get<std::string>("current_user_id");
 
   auto db = app().getDbClient();
 
   try {
-    // First check if a conversation already exists between these users
     auto result = co_await db->execSqlCoro(
         "SELECT c.id FROM conversations c "
         "JOIN conversation_participants cp1 ON c.id = cp1.conversation_id AND "
@@ -120,30 +184,30 @@ Task<> Chats::create_conversation(
         "JOIN conversation_participants cp2 ON c.id = cp2.conversation_id AND "
         "cp2.user_id = $2 "
         "LIMIT 1",
-        std::stoi(user_id), other_user_id);
+        convert::string_to_int(user_id).value(), other_user_id);
 
     if (!result.empty()) {
-      // Conversation already exists
-      Json::Value ret;
-      ret["status"] = "success";
-      ret["conversation_id"] = result[0]["id"].as<int>();
-      ret["message"] = "Conversation already exists";
-      auto resp = HttpResponse::newHttpJsonResponse(ret);
+      CreateConversationResponse ret{
+          .status = "success",
+          .conversation_id = result[0]["id"].as<int>(),
+          .message = "Conversation already exists"};
+      auto resp = HttpResponse::newHttpResponse(k200OK, CT_APPLICATION_JSON);
+      resp->setBody(glz::write_json(ret).value_or(""));
       callback(resp);
       co_return;
     } else {
-      // Create new conversation
       auto insert_result = co_await db->execSqlCoro(
           "INSERT INTO conversations (name) VALUES ($1) RETURNING id, "
           "created_at",
           name);
 
       if (insert_result.empty()) {
-        Json::Value error;
-        error["error"] = "Failed to create conversation";
-        auto resp = HttpResponse::newHttpJsonResponse(error);
-        resp->setStatusCode(k500InternalServerError);
+        SimpleError ret{.error = "Failed to create conversation"};
+        auto resp = HttpResponse::newHttpResponse(k500InternalServerError,
+                                                  CT_APPLICATION_JSON);
+        resp->setBody(glz::write_json(ret).value_or(""));
         callback(resp);
+        co_return;
       }
       int conversation_id = insert_result[0]["id"].as<int>();
       std::string conversation_id_str =
@@ -154,7 +218,8 @@ Task<> Chats::create_conversation(
         co_await db->execSqlCoro(
             "INSERT INTO conversation_participants (conversation_id, "
             "user_id) VALUES ($1, $2), ($1, $3)",
-            conversation_id, std::stoi(user_id), other_user_id);
+            conversation_id, convert::string_to_int(user_id).value(),
+            other_user_id);
 
         // notification
         std::string conversation_topic =
@@ -171,39 +236,37 @@ Task<> Chats::create_conversation(
         LOG_INFO << "User " << user_id << " and " << other_user_id_str
                  << " subscribed to conversation topic: " << conversation_topic;
 
-        Json::Value data_json;
-        data_json["type"] = "chat_created";
-        data_json["id"] = conversation_id_str;
-        data_json["message"] = "New Conversation created";
-        data_json["modified_at"] =
-            insert_result[0]["created_at"].as<std::string>();
+        NotificationMessage msg{
+            .type = "chat_created",
+            .id = conversation_id_str,
+            .message = "New Conversation created",
+            .modified_at = insert_result[0]["created_at"].as<std::string>()};
 
-        Json::FastWriter writer;
-        std::string data = writer.write(data_json);
         ServiceManager::get_instance().get_publisher().publish(
-            conversation_topic, data);
+            conversation_topic, glz::write_json(msg).value_or(""));
 
-        Json::Value ret;
-        ret["status"] = "success";
-        ret["conversation_id"] = conversation_id;
-        auto resp = HttpResponse::newHttpJsonResponse(ret);
+        CreateConversationResponse ret{.status = "success",
+                                       .conversation_id = conversation_id,
+                                       .message = {}};
+        auto resp = HttpResponse::newHttpResponse(k200OK, CT_APPLICATION_JSON);
+        resp->setBody(glz::write_json(ret).value_or(""));
         callback(resp);
       } catch (const DrogonDbException& e) {
         LOG_ERROR << "Database error adding participants: " << e.base().what();
-        Json::Value error;
-        error["error"] = "Database error";
-        auto resp = HttpResponse::newHttpJsonResponse(error);
-        resp->setStatusCode(k500InternalServerError);
+        SimpleError ret{.error = "Database error"};
+        auto resp = HttpResponse::newHttpResponse(k500InternalServerError,
+                                                  CT_APPLICATION_JSON);
+        resp->setBody(glz::write_json(ret).value_or(""));
         callback(resp);
       }
     }
   } catch (const DrogonDbException& e) {
     LOG_ERROR << "Database error checking existing conversation: "
               << e.base().what();
-    Json::Value error;
-    error["error"] = "Database error";
-    auto resp = HttpResponse::newHttpJsonResponse(error);
-    resp->setStatusCode(k500InternalServerError);
+    SimpleError ret{.error = "Database error"};
+    auto resp = HttpResponse::newHttpResponse(k500InternalServerError,
+                                              CT_APPLICATION_JSON);
+    resp->setBody(glz::write_json(ret).value_or(""));
     callback(resp);
   }
 
@@ -215,37 +278,35 @@ Task<> Chats::get_messages(HttpRequestPtr req,
                            std::string conversation_id) {
   std::string user_id =
       req->getAttributes()->get<std::string>("current_user_id");
-  // Validation: Malformed route
-  if (!convert::string_to_int(conversation_id).has_value() ||
-      convert::string_to_int(conversation_id).value() < 0) {
-    Json::Value error;
-    error["error"] = "Invalid conversation_id";
-    auto resp = HttpResponse::newHttpJsonResponse(error);
-    resp->setStatusCode(k400BadRequest);
+
+  auto conv_id_optional = convert::string_to_int(conversation_id);
+  if (!conv_id_optional || conv_id_optional.value() < 0) {
+    SimpleError ret{.error = "Invalid conversation_id"};
+    auto resp =
+        HttpResponse::newHttpResponse(k400BadRequest, CT_APPLICATION_JSON);
+    resp->setBody(glz::write_json(ret).value_or(""));
     callback(resp);
     co_return;
   }
-
+  int conv_id = conv_id_optional.value();
   auto db = app().getDbClient();
 
   try {
-    // First verify the user is a participant in this conversation
     auto result = co_await db->execSqlCoro(
         "SELECT 1 FROM conversation_participants WHERE conversation_id = $1 "
         "AND "
         "user_id = $2",
-        std::stoi(conversation_id), std::stoi(user_id));
+        conv_id, convert::string_to_int(user_id).value());
 
     if (result.empty()) {
-      Json::Value error;
-      error["error"] = "Unauthorized access to conversation";
-      auto resp = HttpResponse::newHttpJsonResponse(error);
-      resp->setStatusCode(k403Forbidden);
+      SimpleError ret{.error = "Unauthorized access to conversation"};
+      auto resp =
+          HttpResponse::newHttpResponse(k403Forbidden, CT_APPLICATION_JSON);
+      resp->setBody(glz::write_json(ret).value_or(""));
       callback(resp);
       co_return;
     }
 
-    // Get messages for the conversation
     auto messages_result = co_await db->execSqlCoro(
         "SELECT m.id, m.sender_id, u.username as sender_name, m.content, "
         "m.message_type, m.is_read, m.created_at, m.metadata "
@@ -253,36 +314,36 @@ Task<> Chats::get_messages(HttpRequestPtr req,
         "JOIN users u ON m.sender_id = u.id "
         "WHERE m.conversation_id = $1 "
         "ORDER BY m.created_at ASC",
-        std::stoi(conversation_id));
+        conv_id);
 
-    Json::Value messages(Json::arrayValue);
+    std::vector<Message> messages_list;
+    messages_list.reserve(messages_result.size());
     for (const auto& row : messages_result) {
-      Json::Value message;
       int message_id = row["id"].as<int>();
-      message["id"] = message_id;
-      message["sender_id"] = row["sender_id"].as<int>();
-      message["sender_name"] = row["sender_name"].as<std::string>();
-      message["content"] = row["content"].as<std::string>();
-      message["message_type"] = row["message_type"].as<std::string>();
-      message["is_read"] = row["is_read"].as<bool>();
-      message["created_at"] = row["created_at"].as<std::string>();
-      message["metadata"] = row["metadata"].as<std::string>();
-
-      message["media"] =
-          row["message_type"].as<std::string>() == "text"
-              ? Json::Value(Json::nullValue)
-              : co_await get_media_attachments("message", message_id);
-      messages.append(message);
+      auto media_attachments =
+          row["message_type"].as<std::string>() != "text"
+              ? co_await get_media_attachments("message", message_id)
+              : std::unexpected<std::string>("failed");
+      messages_list.emplace_back(
+          Message{.id = message_id,
+                  .sender_id = row["sender_id"].as<int>(),
+                  .sender_name = row["sender_name"].as<std::string>(),
+                  .content = row["content"].as<std::string>(),
+                  .message_type = row["message_type"].as<std::string>(),
+                  .is_read = row["is_read"].as<bool>(),
+                  .created_at = row["created_at"].as<std::string>(),
+                  .metadata = row["metadata"].as<std::string>(),
+                  .media = media_attachments.value_or({})});
     }
-
-    auto resp = HttpResponse::newHttpJsonResponse(messages);
+    auto resp = HttpResponse::newHttpResponse(k200OK, CT_APPLICATION_JSON);
+    resp->setBody(glz::write_json(messages_list).value_or(""));
     callback(resp);
   } catch (const DrogonDbException& e) {
     LOG_ERROR << "Database error: " << e.base().what();
-    Json::Value error;
-    error["error"] = "Database error";
-    auto resp = HttpResponse::newHttpJsonResponse(error);
-    resp->setStatusCode(k500InternalServerError);
+    SimpleError ret{.error = "Database error"};
+    auto resp = HttpResponse::newHttpResponse(k500InternalServerError,
+                                              CT_APPLICATION_JSON);
+    resp->setBody(glz::write_json(ret).value_or(""));
     callback(resp);
   }
 
@@ -292,80 +353,66 @@ Task<> Chats::get_messages(HttpRequestPtr req,
 Task<> Chats::send_message(HttpRequestPtr req,
                            std::function<void(const HttpResponsePtr&)> callback,
                            std::string conversation_id) {
-  auto json = req->getJsonObject();
   std::string user_id =
       req->getAttributes()->get<std::string>("current_user_id");
 
-  // Validation: Malformed route
-  if (!convert::string_to_int(conversation_id).has_value() ||
-      convert::string_to_int(conversation_id).value() < 0) {
-    Json::Value error;
-    error["error"] = "Invalid conversation_id";
-    auto resp = HttpResponse::newHttpJsonResponse(error);
-    resp->setStatusCode(k400BadRequest);
+  auto conv_id_optional = convert::string_to_int(conversation_id);
+  if (!conv_id_optional || conv_id_optional.value() < 0) {
+    SimpleError ret{.error = "Invalid conversation_id"};
+    auto resp =
+        HttpResponse::newHttpResponse(k400BadRequest, CT_APPLICATION_JSON);
+    resp->setBody(glz::write_json(ret).value_or(""));
     callback(resp);
     co_return;
   }
+  int conv_id = conv_id_optional.value();
 
-  /**
-   * content and media can't be both missing.
-   * if content is provided (and media isn't), it can't be empty.
-   * if media is provided it should be either null or an array.
-   */
-  if (!json || (!(*json).isMember("content") && !(*json).isMember("media")) ||
-      ((*json).isMember("content") && !(*json).isMember("media") &&
-       (*json)["content"].asString().empty()) ||
-      ((*json).isMember("media") &&
-       !((*json)["media"].isNull() || (*json)["media"].isArray()))) {
+  SendMessageRequest send_msg_req;
+  auto parse_error = utilities::strict_read_json(send_msg_req, req->getBody());
+
+  // Validation: content and media can't be both missing. If content is provided
+  // (and media isn't), it can't be empty. If media is provided it should be
+  // either null or an array.
+  if (parse_error || (!send_msg_req.content && !send_msg_req.media) ||
+      (send_msg_req.content && !send_msg_req.media &&
+       send_msg_req.content->empty()) ||
+      (send_msg_req.media && !send_msg_req.media->empty() &&
+       send_msg_req.media->size() > service::MAX_MEDIA_SIZE)) {
     LOG_INFO << "Message content or media is required, content a string, media "
-                "an array of strings";
-    Json::Value error;
-    error["error"] =
-        "Message content or media is required, content a string, media an "
-        "array of strings";
-    auto resp = HttpResponse::newHttpJsonResponse(error);
-    resp->setStatusCode(k400BadRequest);
+                "an array of strings. Max media size is "
+             << service::MAX_MEDIA_SIZE;
+    SimpleError ret{.error =
+                        "Message content or media is required, content a "
+                        "string, media an array of strings"};
+    auto resp =
+        HttpResponse::newHttpResponse(k400BadRequest, CT_APPLICATION_JSON);
+    resp->setBody(glz::write_json(ret).value_or(""));
     callback(resp);
     co_return;
   }
 
-  std::string content =
-      (*json).isMember("content") ? (*json)["content"].asString() : "";
-  Json::Value media_array = (*json).isMember("media")
-                                ? (*json)["media"]
-                                : Json::Value(Json::arrayValue);
-
-  if (media_array.size() > MAX_MEDIA_SIZE) {
-    Json::Value error;
-    error["error"] = "Maximum of 5 media items allowed per message";
-    auto resp = HttpResponse::newHttpJsonResponse(error);
-    resp->setStatusCode(k400BadRequest);
-    callback(resp);
-    co_return;
-  }
+  std::string content = send_msg_req.content.value_or("");
 
   std::string message_type = "text";
-  if (!media_array.empty()) {
+  if (send_msg_req.media.has_value()) {
     message_type = content.empty() ? "media" : "mixed";
   }
 
   auto db = app().getDbClient();
 
   try {
-    int current_user_id = std::stoi(user_id);
-    // First verify the user is a participant in this conversation
+    int current_user_id = convert::string_to_int(user_id).value();
     auto result = co_await db->execSqlCoro(
         "SELECT 1 FROM conversation_participants WHERE conversation_id = $1 "
         "AND "
         "user_id = $2",
-        std::stoi(conversation_id), current_user_id);
+        conv_id, current_user_id);
 
     if (result.empty()) {
-      // User is not a participant
-      Json::Value error;
-      error["error"] = "Unauthorized access to conversation";
-      auto resp = HttpResponse::newHttpJsonResponse(error);
-      resp->setStatusCode(k403Forbidden);
+      SimpleError ret{.error = "Unauthorized access to conversation"};
+      auto resp =
+          HttpResponse::newHttpResponse(k403Forbidden, CT_APPLICATION_JSON);
+      resp->setBody(glz::write_json(ret).value_or(""));
       callback(resp);
       co_return;
     }
@@ -376,7 +423,7 @@ Task<> Chats::send_message(HttpRequestPtr req,
           "INSERT INTO messages (conversation_id, sender_id, content, "
           "message_type) "
           "VALUES ($1, $2, $3, $4) RETURNING id, created_at",
-          std::stoi(conversation_id), current_user_id, content, message_type);
+          conv_id, current_user_id, content, message_type);
 
       if (insert_result.empty()) {
         throw std::runtime_error("Initial message insert failed");
@@ -385,78 +432,75 @@ Task<> Chats::send_message(HttpRequestPtr req,
       int message_id = insert_result[0]["id"].as<int>();
       std::string created_at = insert_result[0]["created_at"].as<std::string>();
 
-      std::size_t media_array_size = media_array.size();
-      Json::Value processed_media = co_await process_media_attachments(
-          std::move(media_array), transaction, current_user_id, "message",
-          message_id);
-      if (processed_media == Json::nullValue ||
-          processed_media.size() < media_array_size) {
-        LOG_ERROR << " Some Media info was not found";
-        transaction->rollback();
-        std::string error_string;
-        for (const auto& media_item : processed_media) {
-          error_string += media_item["file_name"].asString() + ", ";
+      std::expected<std::vector<MediaQuickInfo>, std::string> processed_media;
+      if (send_msg_req.media.has_value() && !send_msg_req.media->empty()) {
+        std::size_t media_array_size = send_msg_req.media->size();
+        processed_media = co_await process_media_attachments(
+            std::move(*send_msg_req.media), transaction, current_user_id,
+            "message", message_id);
+        if (!processed_media.has_value() ||
+            processed_media->size() < media_array_size) {
+          LOG_ERROR << " Some Media info was not found";
+          transaction->rollback();
+          std::string error_string;
+          for (const auto& media_item : *processed_media) {
+            error_string += media_item.filename + ", ";
+          }
+          SimpleError ret{.error =
+                              std::format("Media info not found or processed, "
+                                          "only the following media items "
+                                          "were processed:\n{}",
+                                          error_string)};
+          auto resp = HttpResponse::newHttpResponse(k400BadRequest,
+                                                    CT_APPLICATION_JSON);
+          resp->setBody(glz::write_json(ret).value_or(""));
+          callback(resp);
+          co_return;
         }
-        Json::Value error;
-        error["error"] = std::format(
-            "Media info not found or processed, only the following media items "
-            "were processed:\n{}",
-            error_string);
-        auto resp = HttpResponse::newHttpJsonResponse(error);
-        resp->setStatusCode(k400BadRequest);
-        callback(resp);
-        co_return;
       }
-      // end transaction
 
-      // notification
       std::string chat_topic = create_topic("chat", conversation_id);
 
-      Json::Value chat_data_json;
-      chat_data_json["type"] = "message_sent";
-      chat_data_json["id"] = conversation_id;
-      chat_data_json["message"] = message_type != "text"
-                                      ? std::format("Media shared: {}", content)
-                                      : content;
-      chat_data_json["modified_at"] = created_at;
+      NotificationMessage msg{
+          .type = "message_sent",
+          .id = conversation_id,
+          .message = message_type != "text"
+                         ? std::format("Media shared: {}", content)
+                         : content,
+          .modified_at = created_at};
 
-      if (!processed_media.empty()) {
-        chat_data_json["media"] = processed_media;
-      }
-
-      Json::FastWriter writer;
-      std::string chat_data = writer.write(chat_data_json);
-
-      ServiceManager::get_instance().get_publisher().publish(chat_topic,
-                                                             chat_data);
-      Json::Value ret;
-      ret["status"] = "success";
-      ret["message_id"] = message_id;
-      ret["created_at"] = created_at;
-      ret["message_type"] = message_type;
-      if (!processed_media.empty()) {
-        ret["media"] = processed_media;
-      }
-      auto resp = HttpResponse::newHttpJsonResponse(ret);
+      ServiceManager::get_instance().get_publisher().publish(
+          chat_topic, glz::write_json(msg).value_or(""));
+      SendMessageResponse ret{
+          .status = "success",
+          .message_id = message_id,
+          .created_at = created_at,
+          .message_type = message_type,
+          .media = processed_media->empty()
+                       ? std::nullopt
+                       : std::make_optional(*processed_media)};
+      auto resp = HttpResponse::newHttpResponse(k200OK, CT_APPLICATION_JSON);
+      resp->setBody(glz::write_json(ret).value_or(""));
       callback(resp);
 
       co_return;
     } catch (const std::exception& e) {
       LOG_ERROR << "Failed to send message: " << e.what();
       transaction->rollback();
-      Json::Value error;
-      error["error"] = std::format("Failed to send message: {}", e.what());
-      auto resp = HttpResponse::newHttpJsonResponse(error);
-      resp->setStatusCode(k500InternalServerError);
+      SimpleError ret{.error =
+                          std::format("Failed to send message: {}", e.what())};
+      auto resp = HttpResponse::newHttpResponse(k500InternalServerError,
+                                                CT_APPLICATION_JSON);
+      resp->setBody(glz::write_json(ret).value_or(""));
       callback(resp);
       co_return;
     }
   } catch (const DrogonDbException& e) {
     LOG_ERROR << "Database error: " << e.base().what();
-    Json::Value error;
-    error["error"] = "Database error";
-    auto resp = HttpResponse::newHttpJsonResponse(error);
-    resp->setStatusCode(k500InternalServerError);
+    SimpleError ret{.error = "Database error"};
+    auto resp = HttpResponse::newHttpResponse(k500InternalServerError,
+                                              CT_APPLICATION_JSON);
+    resp->setBody(glz::write_json(ret).value_or(""));
     callback(resp);
   }
 
@@ -471,32 +515,30 @@ Task<> Chats::get_conversation_by_offer(
       req->getAttributes()->get<std::string>("current_user_id");
   auto db = app().getDbClient();
 
-  // Validation: Malformed route
-  if (!convert::string_to_int(offer_id).has_value() ||
-      convert::string_to_int(offer_id).value() < 0) {
-    Json::Value error;
-    error["error"] = "Invalid offer ID";
-    auto resp = HttpResponse::newHttpJsonResponse(error);
-    resp->setStatusCode(k400BadRequest);
+  auto offer_id_optional = convert::string_to_int(offer_id);
+  if (!offer_id_optional || offer_id_optional.value() < 0) {
+    SimpleError ret{.error = "Invalid offer ID"};
+    auto resp =
+        HttpResponse::newHttpResponse(k400BadRequest, CT_APPLICATION_JSON);
+    resp->setBody(glz::write_json(ret).value_or(""));
     callback(resp);
     co_return;
   }
+  int offer_id_int = offer_id_optional.value();
 
   try {
-    // First, check if the user is authorized to access this offer's
-    // conversation
     auto result = co_await db->execSqlCoro(
         "SELECT o.*, p.user_id AS post_user_id "
         "FROM offers o "
         "JOIN posts p ON o.post_id = p.id "
         "WHERE o.id = $1",
-        std::stoi(offer_id));
+        offer_id_int);
 
     if (result.empty()) {
-      Json::Value error;
-      error["error"] = "Offer not found";
-      auto resp = HttpResponse::newHttpJsonResponse(error);
-      resp->setStatusCode(k404NotFound);
+      SimpleError ret{.error = "Offer not found"};
+      auto resp =
+          HttpResponse::newHttpResponse(k404NotFound, CT_APPLICATION_JSON);
+      resp->setBody(glz::write_json(ret).value_or(""));
       callback(resp);
       co_return;
     }
@@ -504,85 +546,84 @@ Task<> Chats::get_conversation_by_offer(
     int offer_user_id = result[0]["user_id"].as<int>();
     int post_user_id = result[0]["post_user_id"].as<int>();
 
-    // Only offer creator or post owner can access the conversation
-    if (std::stoi(current_user_id) != offer_user_id &&
-        std::stoi(current_user_id) != post_user_id) {
-      Json::Value error;
-      error["error"] = "Unauthorized";
-      auto resp = HttpResponse::newHttpJsonResponse(error);
-      resp->setStatusCode(k403Forbidden);
+    if (convert::string_to_int(current_user_id).value() != offer_user_id &&
+        convert::string_to_int(current_user_id).value() != post_user_id) {
+      SimpleError ret{.error = "Unauthorized"};
+      auto resp =
+          HttpResponse::newHttpResponse(k403Forbidden, CT_APPLICATION_JSON);
+      resp->setBody(glz::write_json(ret).value_or(""));
       callback(resp);
       co_return;
     }
 
-    // Find conversation between these two users
     auto conv_result = co_await db->execSqlCoro(
         "SELECT c.id FROM conversations c "
         "JOIN conversation_participants cp1 ON c.id = cp1.conversation_id "
         "JOIN conversation_participants cp2 ON c.id = cp2.conversation_id "
         "WHERE cp1.user_id = $1 AND cp2.user_id = $2 "
         "LIMIT 1",
-        std::stoi(current_user_id),
-        (std::stoi(current_user_id) == offer_user_id ? post_user_id
-                                                     : offer_user_id));
+        convert::string_to_int(current_user_id).value(),
+        (convert::string_to_int(current_user_id).value() == offer_user_id
+             ? post_user_id
+             : offer_user_id));
 
     if (conv_result.empty()) {
-      // No conversation exists yet, create one
       auto new_conv_result = co_await db->execSqlCoro(
           "INSERT INTO conversations (name) VALUES ($1) RETURNING id",
           "Offer #" + offer_id + " Conversation");
 
       if (new_conv_result.empty()) {
-        Json::Value error;
-        error["error"] = "Failed to create conversation";
-        auto resp = HttpResponse::newHttpJsonResponse(error);
-        resp->setStatusCode(k500InternalServerError);
+        SimpleError ret{.error = "Failed to create conversation"};
+        auto resp = HttpResponse::newHttpResponse(k500InternalServerError,
+                                                  CT_APPLICATION_JSON);
+        resp->setBody(glz::write_json(ret).value_or(""));
         callback(resp);
         co_return;
       }
 
       int conversation_id = new_conv_result[0]["id"].as<int>();
 
-      // Add participants
       try {
         co_await db->execSqlCoro(
             "INSERT INTO conversation_participants "
             "(conversation_id, user_id) VALUES ($1, $2), ($1, $3)",
-            conversation_id, std::stoi(current_user_id),
-            (std::stoi(current_user_id) == offer_user_id ? post_user_id
-                                                         : offer_user_id));
+            conversation_id, convert::string_to_int(current_user_id).value(),
+            (convert::string_to_int(current_user_id).value() == offer_user_id
+                 ? post_user_id
+                 : offer_user_id));
 
-        Json::Value response;
-        response["status"] = "success";
-        response["conversation_id"] = conversation_id;
-        response["is_new"] = true;
+        GetConversationByOfferResponse response{
+            .status = "success",
+            .conversation_id = conversation_id,
+            .is_new = true};
 
-        auto resp = HttpResponse::newHttpJsonResponse(response);
+        auto resp = HttpResponse::newHttpResponse(k200OK, CT_APPLICATION_JSON);
+        resp->setBody(glz::write_json(response).value_or(""));
         callback(resp);
       } catch (const DrogonDbException& e) {
         LOG_ERROR << "Database error adding participants: " << e.base().what();
-        Json::Value error;
-        error["error"] = "Database error";
-        auto resp = HttpResponse::newHttpJsonResponse(error);
-        resp->setStatusCode(k500InternalServerError);
+        SimpleError ret{.error = "Database error"};
+        auto resp = HttpResponse::newHttpResponse(k500InternalServerError,
+                                                  CT_APPLICATION_JSON);
+        resp->setBody(glz::write_json(ret).value_or(""));
         callback(resp);
       }
     } else {
-      // Conversation exists
-      Json::Value response;
-      response["status"] = "success";
-      response["conversation_id"] = conv_result[0]["id"].as<int>();
-      response["is_new"] = false;
+      GetConversationByOfferResponse response{
+          .status = "success",
+          .conversation_id = conv_result[0]["id"].as<int>(),
+          .is_new = false};
 
-      auto resp = HttpResponse::newHttpJsonResponse(response);
+      auto resp = HttpResponse::newHttpResponse(k200OK, CT_APPLICATION_JSON);
+      resp->setBody(glz::write_json(response).value_or(""));
       callback(resp);
     }
   } catch (const DrogonDbException& e) {
     LOG_ERROR << "Database error: " << e.base().what();
-    Json::Value error;
-    error["error"] = "Database error";
-    auto resp = HttpResponse::newHttpJsonResponse(error);
-    resp->setStatusCode(k500InternalServerError);
+    SimpleError ret{.error = "Database error"};
+    auto resp = HttpResponse::newHttpResponse(k500InternalServerError,
+                                              CT_APPLICATION_JSON);
+    resp->setBody(glz::write_json(ret).value_or(""));
     callback(resp);
   }
 
@@ -595,44 +636,52 @@ Task<> Chats::mark_messages_as_read(
   std::string user_id =
       req->getAttributes()->get<std::string>("current_user_id");
 
+  auto conv_id_optional = convert::string_to_int(conversation_id);
+  if (!conv_id_optional || conv_id_optional.value() < 0) {
+    SimpleError ret{.error = "Invalid conversation_id"};
+    auto resp =
+        HttpResponse::newHttpResponse(k400BadRequest, CT_APPLICATION_JSON);
+    resp->setBody(glz::write_json(ret).value_or(""));
+    callback(resp);
+    co_return;
+  }
+  int conv_id = conv_id_optional.value();
+
   auto db = app().getDbClient();
 
   try {
-    // First verify the user is a participant in this conversation
     auto result = co_await db->execSqlCoro(
         "SELECT 1 FROM conversation_participants WHERE conversation_id = $1 "
         "AND "
         "user_id = $2",
-        std::stoi(conversation_id), std::stoi(user_id));
+        conv_id, convert::string_to_int(user_id).value());
 
     if (result.empty()) {
-      // User is not a participant
-      Json::Value error;
-      error["error"] = "Unauthorized access to conversation";
-      auto resp = HttpResponse::newHttpJsonResponse(error);
-      resp->setStatusCode(k403Forbidden);
+      SimpleError ret{.error = "Unauthorized access to conversation"};
+      auto resp =
+          HttpResponse::newHttpResponse(k403Forbidden, CT_APPLICATION_JSON);
+      resp->setBody(glz::write_json(ret).value_or(""));
       callback(resp);
       co_return;
     }
 
-    // Mark all messages not sent by the current user as read
     auto update_result = co_await db->execSqlCoro(
         "UPDATE messages SET is_read = true "
         "WHERE conversation_id = $1 AND sender_id != $2 AND is_read = false "
         "RETURNING id",
-        std::stoi(conversation_id), std::stoi(user_id));
+        conv_id, convert::string_to_int(user_id).value());
 
-    Json::Value ret;
-    ret["status"] = "success";
-    ret["messages_marked"] = (int)update_result.size();
-    auto resp = HttpResponse::newHttpJsonResponse(ret);
+    MarkMessagesAsReadResponse ret{
+        .status = "success", .messages_marked = (int)update_result.size()};
+    auto resp = HttpResponse::newHttpResponse(k200OK, CT_APPLICATION_JSON);
+    resp->setBody(glz::write_json(ret).value_or(""));
     callback(resp);
   } catch (const DrogonDbException& e) {
     LOG_ERROR << "Database error: " << e.base().what();
-    Json::Value error;
-    error["error"] = "Database error";
-    auto resp = HttpResponse::newHttpJsonResponse(error);
-    resp->setStatusCode(k500InternalServerError);
+    SimpleError ret{.error = "Database error"};
+    auto resp = HttpResponse::newHttpResponse(k500InternalServerError,
+                                              CT_APPLICATION_JSON);
+    resp->setBody(glz::write_json(ret).value_or(""));
     callback(resp);
   }
 
@@ -647,25 +696,25 @@ Task<> Chats::get_unread_count(
   auto db = app().getDbClient();
 
   try {
-    // Get count of unread messages across all conversations
     auto result = co_await db->execSqlCoro(
         "SELECT COUNT(*) as unread_count "
         "FROM messages m "
         "JOIN conversation_participants cp ON m.conversation_id = "
         "cp.conversation_id "
         "WHERE cp.user_id = $1 AND m.sender_id != $1 AND m.is_read = false",
-        std::stoi(user_id));
+        convert::string_to_int(user_id).value());
 
-    Json::Value ret;
-    ret["unread_count"] = result[0]["unread_count"].as<int>();
-    auto resp = HttpResponse::newHttpJsonResponse(ret);
+    UnreadCountResponse ret{.unread_count =
+                                result[0]["unread_count"].as<int>()};
+    auto resp = HttpResponse::newHttpResponse(k200OK, CT_APPLICATION_JSON);
+    resp->setBody(glz::write_json(ret).value_or(""));
     callback(resp);
   } catch (const DrogonDbException& e) {
     LOG_ERROR << "Database error: " << e.base().what();
-    Json::Value error;
-    error["error"] = "Database error";
-    auto resp = HttpResponse::newHttpJsonResponse(error);
-    resp->setStatusCode(k500InternalServerError);
+    SimpleError ret{.error = "Database error"};
+    auto resp = HttpResponse::newHttpResponse(k500InternalServerError,
+                                              CT_APPLICATION_JSON);
+    resp->setBody(glz::write_json(ret).value_or(""));
     callback(resp);
   }
 

--- a/controllers/chats.hpp
+++ b/controllers/chats.hpp
@@ -2,6 +2,8 @@
 
 #include <drogon/HttpController.h>
 
+#include <string>
+
 namespace api {
 
 namespace v1 {
@@ -38,32 +40,29 @@ class Chats : public drogon::HttpController<Chats> {
 
   static drogon::Task<> get_conversations(
       drogon::HttpRequestPtr req,
-      std::function<void(const drogon::HttpResponsePtr &)> callback);
+      std::function<void(const drogon::HttpResponsePtr&)> callback);
   static drogon::Task<> create_conversation(
       drogon::HttpRequestPtr req,
-      std::function<void(const drogon::HttpResponsePtr &)> callback);
+      std::function<void(const drogon::HttpResponsePtr&)> callback);
   static drogon::Task<> get_messages(
       drogon::HttpRequestPtr req,
-      std::function<void(const drogon::HttpResponsePtr &)> callback,
+      std::function<void(const drogon::HttpResponsePtr&)> callback,
       std::string conversation_id);
   static drogon::Task<> send_message(
       drogon::HttpRequestPtr req,
-      std::function<void(const drogon::HttpResponsePtr &)> callback,
+      std::function<void(const drogon::HttpResponsePtr&)> callback,
       std::string conversation_id);
-
   static drogon::Task<> get_conversation_by_offer(
       drogon::HttpRequestPtr req,
-      std::function<void(const drogon::HttpResponsePtr &)> callback,
+      std::function<void(const drogon::HttpResponsePtr&)> callback,
       std::string offer_id);
-
   static drogon::Task<> mark_messages_as_read(
       drogon::HttpRequestPtr req,
-      std::function<void(const drogon::HttpResponsePtr &)> callback,
+      std::function<void(const drogon::HttpResponsePtr&)> callback,
       std::string conversation_id);
   static drogon::Task<> get_unread_count(
       drogon::HttpRequestPtr req,
-      std::function<void(const drogon::HttpResponsePtr &)> callback);
+      std::function<void(const drogon::HttpResponsePtr&)> callback);
 };
-
 }  // namespace v1
 }  // namespace api

--- a/controllers/common_req_n_resp.hpp
+++ b/controllers/common_req_n_resp.hpp
@@ -1,0 +1,52 @@
+#ifndef COMMON_REQ_N_RESP_HPP
+#define COMMON_REQ_N_RESP_HPP
+
+#include <optional>
+#include <string>
+#include <vector>
+
+struct StatusResponse {
+  std::string status;
+  std::string message;
+};
+
+struct SimpleStatus {
+  std::string status;
+};
+struct SimpleError {
+  std::string error;
+};
+
+struct MediaQuickInfo {
+  int media_id;
+  std::string object_key;
+  std::string filename;
+  std::string mime_type;
+  int64_t size = 0;
+  // No metadata for now
+};
+
+struct MediaInput {
+  std::vector<std::string> object_keys;
+};
+
+struct DeleteMediaRequest {
+  std::vector<int> media_ids;
+};
+
+struct MediaResponse {
+  std::vector<int> media_ids;
+};
+
+struct MediaInfoResponse {
+  std::vector<MediaQuickInfo> media;
+};
+
+struct NotificationMessage {
+  std::string type;
+  std::string id;
+  std::string message;
+  std::string modified_at;
+};
+
+#endif  // COMMON_REQ_N_RESP_HPP

--- a/controllers/community.hpp
+++ b/controllers/community.hpp
@@ -2,9 +2,11 @@
 
 #include <drogon/HttpController.h>
 
-namespace api {
-namespace v1 {
+#include <string>
 
+namespace api {
+
+namespace v1 {
 using drogon::Get;
 using drogon::Options;
 using drogon::Post;
@@ -13,7 +15,6 @@ using drogon::Put;
 class Community : public drogon::HttpController<Community> {
  public:
   METHOD_LIST_BEGIN
-  // Gets
   ADD_METHOD_TO(Community::get_posts, "/api/v1/posts", Get, Options,
                 "CorsMiddleware", "AuthMiddleware");
   ADD_METHOD_TO(Community::get_post_by_id, "/api/v1/posts/{id}", Get, Options,
@@ -25,7 +26,6 @@ class Community : public drogon::HttpController<Community> {
   ADD_METHOD_TO(Community::get_popular_tags, "/api/v1/posts/tags", Get, Options,
                 "CorsMiddleware", "AuthMiddleware");
 
-  // Posts
   ADD_METHOD_TO(Community::create_post, "/api/v1/posts", Post, Options,
                 "CorsMiddleware", "AuthMiddleware");
   ADD_METHOD_TO(Community::subscribe_to_post, "/api/v1/posts/{id}/subscribe",
@@ -41,7 +41,6 @@ class Community : public drogon::HttpController<Community> {
                 "/api/v1/entity/{name}/unsubscribe", Post, Options,
                 "CorsMiddleware", "AuthMiddleware");
 
-  // Puts
   ADD_METHOD_TO(Community::update_post, "/api/v1/posts/{id}", Put, Options,
                 "CorsMiddleware", "AuthMiddleware");
   METHOD_LIST_END

--- a/controllers/dashboard.cc
+++ b/controllers/dashboard.cc
@@ -1,48 +1,67 @@
 #include "dashboard.hpp"
 
 #include <drogon/HttpResponse.h>
-#include <drogon/HttpTypes.h>
-#include <drogon/orm/Criteria.h>
-#include <drogon/orm/DbClient.h>
-#include <drogon/orm/Exception.h>
-#include <drogon/orm/Field.h>
-#include <drogon/orm/Mapper.h>
-#include <drogon/orm/Result.h>
-#include <drogon/orm/ResultIterator.h>
-#include <drogon/orm/Row.h>
-#include <drogon/orm/SqlBinder.h>
+
+#include "../utilities/conversion.hpp"
+#include "../utilities/json_manipulation.hpp"
+#include "common_req_n_resp.hpp"
 
 using drogon::app;
-using drogon::orm::DrogonDbException;
+using drogon::CT_APPLICATION_JSON;
+using drogon::HttpResponse;
 
-using namespace api::v1;
+#include <algorithm>
+#include <string>
+#include <unordered_map>
+
+using api::v1::Dashboard;
+
+struct OrdersData {
+  std::unordered_map<std::string, int> orders;
+};
 
 drogon::Task<> Dashboard::get_dashboard_data(
     drogon::HttpRequestPtr req,
     std::function<void(const drogon::HttpResponsePtr&)> callback) {
   auto db = app().getDbClient();
 
-  try {
-    // Fetch orders data
-    auto result = co_await db->execSqlCoro(
-        "SELECT status, COUNT(*) FROM orders GROUP BY status");
+  // Pagination parameters
+  std::size_t page = 1;
+  std::size_t pageSize = 20;
 
-    Json::Value orders_data;
+  if (!req->getParameter("page").empty()) {
+    page = std::max(
+        1, convert::string_to_int(req->getParameter("page")).value_or(1));
+  }
+  if (!req->getParameter("pageSize").empty()) {
+    pageSize = std::max(
+        1, std::min(100, convert::string_to_int(req->getParameter("pageSize"))
+                             .value_or(20)));
+  }
+  std::size_t offset = (page - 1) * pageSize;
+
+  try {
+    auto result = co_await db->execSqlCoro(
+        "SELECT status, COUNT(*) as count FROM orders GROUP BY status ORDER BY "
+        "status LIMIT $1 OFFSET $2",
+        pageSize, offset);
+
+    OrdersData orders_data;
     for (const auto& row : result) {
-      orders_data[row["status"].as<std::string>()] = row["count"].as<int>();
+      orders_data.orders.emplace(row["status"].as<std::string>(),
+                                 row["count"].as<int>());
     }
 
-    // Prepare response
-    Json::Value ret;
-    ret["orders"] = orders_data;
-    auto resp = drogon::HttpResponse::newHttpJsonResponse(ret);
+    auto resp =
+        HttpResponse::newHttpResponse(drogon::k200OK, CT_APPLICATION_JSON);
+    resp->setBody(glz::write_json(orders_data).value_or(""));
     callback(resp);
-  } catch (const DrogonDbException& e) {
+  } catch (const drogon::orm::DrogonDbException& e) {
     LOG_ERROR << "Database error: " << e.base().what();
-    Json::Value error;
-    error["error"] = "Database error";
-    auto resp = drogon::HttpResponse::newHttpJsonResponse(error);
-    resp->setStatusCode(drogon::k500InternalServerError);
+    SimpleError ret{.error = "Database error"};
+    auto resp = HttpResponse::newHttpResponse(drogon::k500InternalServerError,
+                                              CT_APPLICATION_JSON);
+    resp->setBody(glz::write_json(ret).value_or(""));
     callback(resp);
   }
 

--- a/controllers/location.hpp
+++ b/controllers/location.hpp
@@ -3,25 +3,6 @@
 #include <drogon/HttpController.h>
 #include <drogon/orm/DbClient.h>
 
-struct LocationPoint {
-  double latitude;
-  double longitude;
-  double accuracy;
-  std::string user_id;
-  std::string device_id;
-  std::string cluster_id;
-  Json::Value to_json() const {
-    Json::Value json;
-    json["latitude"] = latitude;
-    json["longitude"] = longitude;
-    json["accuracy"] = accuracy;
-    json["user_id"] = user_id;
-    json["device_id"] = device_id;
-    json["cluster_id"] = cluster_id;
-    return json;
-  }
-};
-
 namespace api {
 namespace v1 {
 

--- a/controllers/media_server.cpp
+++ b/controllers/media_server.cpp
@@ -6,11 +6,49 @@
 
 #include <array>
 #include <format>
+#include <optional>
+#include <string>
 
 #include "../services/media_server/s3_service.hpp"
 #include "../services/service_manager.hpp"
+#include "../utilities/json_manipulation.hpp"
+#include "common_req_n_resp.hpp"
 
-using namespace api::v1;
+using api::v1::MediaController;
+using drogon::CT_APPLICATION_JSON;
+
+struct GetUploadUrlRequest {
+  std::string filename;
+  std::optional<bool> is_proof{false};
+  std::optional<std::string> content_type{"application/octet-stream"};
+};
+
+struct GetUploadUrlResponse {
+  std::string upload_url;
+  std::string object_key;
+};
+
+struct VerifyObjectKeyResponse {
+  bool exists;
+};
+
+struct GetMediaMetadataResponse {
+  std::string object_key;
+  std::string content_type;
+  int64_t content_length;
+  std::string last_modified;
+  std::string etag;
+};
+
+struct VerifyProofResponse {
+  bool is_valid;
+  std::string object_key;
+};
+
+struct GetMediaUrlResponse {
+  std::string download_url;
+  std::string content_type;
+};
 
 constexpr auto allowed_file_types = std::to_array<std::string_view>({
     "image/jpeg", "image/png", "image/gif", "image/webp", "video/mp4",
@@ -21,40 +59,40 @@ drogon::Task<> MediaController::get_upload_url(
     const drogon::HttpRequestPtr req,
     std::function<void(const drogon::HttpResponsePtr &)> callback) {
   try {
-    auto json = req->getJsonObject();
+    GetUploadUrlRequest upload_req;
+    auto parse_error = utilities::strict_read_json(upload_req, req->getBody());
 
-    if (!json || json->empty() || !(*json).isMember("filename") ||
-        (*json)["filename"].asString().empty() ||
-        ((*json).isMember("is_proof") && !(*json)["is_proof"].isBool())) {
+    if (parse_error || upload_req.filename.empty()) {
       LOG_ERROR
           << "At least filename is required, is_proof should be a boolean";
-      Json::Value error;
-      error["error"] =
-          "At least filename is required, is_proof should be a boolean";
-      auto resp = drogon::HttpResponse::newHttpJsonResponse(error);
-      resp->setStatusCode(drogon::k400BadRequest);
+      SimpleError error{
+          .error =
+              "At least filename is required, is_proof should be a "
+              "boolean"};
+      auto resp = drogon::HttpResponse::newHttpResponse(drogon::k400BadRequest,
+                                                        CT_APPLICATION_JSON);
+      resp->setBody(glz::write_json(error).value_or(""));
       callback(resp);
       co_return;
     }
 
-    auto file_name = json->get("filename", "nofile").asString();
-    // auto is_proof = json->get("is_proof", false).asBool(); // not used yet
     auto content_type =
-        json->get("content_type", "application/octet-stream").asString();
+        upload_req.content_type.value_or("application/octet-stream");
 
     if (std::find(allowed_file_types.begin(), allowed_file_types.end(),
                   content_type) == allowed_file_types.end()) {
       LOG_ERROR << content_type << " file type not allowed";
-      Json::Value error;
-      error["error"] = std::format("{} file type not allowed", content_type);
-      auto resp = drogon::HttpResponse::newHttpJsonResponse(error);
-      resp->setStatusCode(drogon::k400BadRequest);
+      SimpleError error{
+          .error = std::format("{} file type not allowed", content_type)};
+      auto resp = drogon::HttpResponse::newHttpResponse(drogon::k400BadRequest,
+                                                        CT_APPLICATION_JSON);
+      resp->setBody(glz::write_json(error).value_or(""));
       callback(resp);
       co_return;
     }
 
-    auto object_key =
-        std::format("uploads/{}_{}", UuidGenerator::generate_uuid(), file_name);
+    auto object_key = std::format(
+        "uploads/{}_{}", UuidGenerator::generate_uuid(), upload_req.filename);
 
     auto upload_url = co_await ServiceManager::get_instance()
                           .get_s3_service()
@@ -63,27 +101,28 @@ drogon::Task<> MediaController::get_upload_url(
 
     if (upload_url.empty()) {
       LOG_ERROR << "Failed to generate upload url";
-      Json::Value error;
-      error["error"] = "Failed to generate upload url";
-      auto resp = drogon::HttpResponse::newHttpJsonResponse(error);
-      resp->setStatusCode(drogon::k500InternalServerError);
+      SimpleError error{.error = "Failed to generate upload url"};
+      auto resp = drogon::HttpResponse::newHttpResponse(
+          drogon::k500InternalServerError, CT_APPLICATION_JSON);
+      resp->setBody(glz::write_json(error).value_or(""));
       callback(resp);
       co_return;
     }
 
-    Json::Value response;
-    response["upload_url"] = upload_url;
-    response["object_key"] = object_key;
+    GetUploadUrlResponse response{.upload_url = upload_url,
+                                  .object_key = object_key};
 
-    auto resp = drogon::HttpResponse::newHttpJsonResponse(response);
+    auto resp = drogon::HttpResponse::newHttpResponse(drogon::k200OK,
+                                                      CT_APPLICATION_JSON);
+    resp->setBody(glz::write_json(response).value_or(""));
     callback(resp);
 
   } catch (const std::exception &e) {
-    Json::Value error;
     LOG_ERROR << "Failed to get upload url: " << e.what();
-    error["error"] = e.what();
-    auto resp = drogon::HttpResponse::newHttpJsonResponse(error);
-    resp->setStatusCode(drogon::k500InternalServerError);
+    SimpleError error{.error = e.what()};
+    auto resp = drogon::HttpResponse::newHttpResponse(
+        drogon::k500InternalServerError, CT_APPLICATION_JSON);
+    resp->setBody(glz::write_json(error).value_or(""));
     callback(resp);
   }
   co_return;
@@ -97,10 +136,10 @@ drogon::Task<> MediaController::verify_object_key(
 
     if (object_key.empty()) {
       LOG_ERROR << "object_key is required";
-      Json::Value error;
-      error["error"] = "object_key is required";
-      auto resp = drogon::HttpResponse::newHttpJsonResponse(error);
-      resp->setStatusCode(drogon::k400BadRequest);
+      SimpleError error{.error = "object_key is required"};
+      auto resp = drogon::HttpResponse::newHttpResponse(drogon::k400BadRequest,
+                                                        CT_APPLICATION_JSON);
+      resp->setBody(glz::write_json(error).value_or(""));
       callback(resp);
       co_return;
     }
@@ -109,17 +148,19 @@ drogon::Task<> MediaController::verify_object_key(
         co_await ServiceManager::get_instance().get_s3_service().get_media_info(
             "media", object_key);
 
-    Json::Value response;
-    response["exists"] = info.etag.empty() ? false : true;
+    VerifyObjectKeyResponse response{.exists =
+                                         info.etag.empty() ? false : true};
 
-    auto resp = drogon::HttpResponse::newHttpJsonResponse(response);
+    auto resp = drogon::HttpResponse::newHttpResponse(drogon::k200OK,
+                                                      CT_APPLICATION_JSON);
+    resp->setBody(glz::write_json(response).value_or(""));
     callback(resp);
   } catch (const std::exception &e) {
-    Json::Value error;
     LOG_ERROR << "Failed confirm media: " << e.what();
-    error["error"] = e.what();
-    auto resp = drogon::HttpResponse::newHttpJsonResponse(error);
-    resp->setStatusCode(drogon::k500InternalServerError);
+    SimpleError error{.error = e.what()};
+    auto resp = drogon::HttpResponse::newHttpResponse(
+        drogon::k500InternalServerError, CT_APPLICATION_JSON);
+    resp->setBody(glz::write_json(error).value_or(""));
     callback(resp);
   }
   co_return;
@@ -133,10 +174,10 @@ drogon::Task<> MediaController::get_media_metadata(
 
     if (object_key.empty()) {
       LOG_ERROR << "object_key is required";
-      Json::Value error;
-      error["error"] = "object_key is required";
-      auto resp = drogon::HttpResponse::newHttpJsonResponse(error);
-      resp->setStatusCode(drogon::k400BadRequest);
+      SimpleError error{.error = "object_key is required"};
+      auto resp = drogon::HttpResponse::newHttpResponse(drogon::k400BadRequest,
+                                                        CT_APPLICATION_JSON);
+      resp->setBody(glz::write_json(error).value_or(""));
       callback(resp);
       co_return;
     }
@@ -145,21 +186,22 @@ drogon::Task<> MediaController::get_media_metadata(
         co_await ServiceManager::get_instance().get_s3_service().get_media_info(
             "media", object_key);
 
-    Json::Value response;
-    response["object_key"] = info.object_key;
-    response["content_type"] = info.content_type;
-    response["content_length"] = info.content_length;
-    response["last_modified"] = info.last_modified;
-    response["etag"] = info.etag;
+    GetMediaMetadataResponse response{.object_key = info.object_key,
+                                      .content_type = info.content_type,
+                                      .content_length = info.content_length,
+                                      .last_modified = info.last_modified,
+                                      .etag = info.etag};
 
-    auto resp = drogon::HttpResponse::newHttpJsonResponse(response);
+    auto resp = drogon::HttpResponse::newHttpResponse(drogon::k200OK,
+                                                      CT_APPLICATION_JSON);
+    resp->setBody(glz::write_json(response).value_or(""));
     callback(resp);
   } catch (const std::exception &e) {
-    Json::Value error;
     LOG_ERROR << "Failed confirm media: " << e.what();
-    error["error"] = e.what();
-    auto resp = drogon::HttpResponse::newHttpJsonResponse(error);
-    resp->setStatusCode(drogon::k500InternalServerError);
+    SimpleError error{.error = e.what()};
+    auto resp = drogon::HttpResponse::newHttpResponse(
+        drogon::k500InternalServerError, CT_APPLICATION_JSON);
+    resp->setBody(glz::write_json(error).value_or(""));
     callback(resp);
   }
   co_return;
@@ -173,10 +215,10 @@ drogon::Task<> MediaController::verify_proof(
 
     if (object_key.empty()) {
       LOG_ERROR << "object_key is required";
-      Json::Value error;
-      error["error"] = "object_key is required";
-      auto resp = drogon::HttpResponse::newHttpJsonResponse(error);
-      resp->setStatusCode(drogon::k400BadRequest);
+      SimpleError error{.error = "object_key is required"};
+      auto resp = drogon::HttpResponse::newHttpResponse(drogon::k400BadRequest,
+                                                        CT_APPLICATION_JSON);
+      resp->setBody(glz::write_json(error).value_or(""));
       callback(resp);
       co_return;
     }
@@ -185,18 +227,19 @@ drogon::Task<> MediaController::verify_proof(
         co_await ServiceManager::get_instance().get_s3_service().process_media(
             "media", object_key);
 
-    Json::Value response;
-    response["is_valid"] = is_valid;
-    response["object_key"] = object_key;
+    VerifyProofResponse response{.is_valid = is_valid,
+                                 .object_key = object_key};
 
-    auto resp = drogon::HttpResponse::newHttpJsonResponse(response);
+    auto resp = drogon::HttpResponse::newHttpResponse(drogon::k200OK,
+                                                      CT_APPLICATION_JSON);
+    resp->setBody(glz::write_json(response).value_or(""));
     callback(resp);
   } catch (const std::exception &e) {
-    Json::Value error;
     LOG_ERROR << "Failed verify proof: " << e.what();
-    error["error"] = e.what();
-    auto resp = drogon::HttpResponse::newHttpJsonResponse(error);
-    resp->setStatusCode(drogon::k500InternalServerError);
+    SimpleError error{.error = e.what()};
+    auto resp = drogon::HttpResponse::newHttpResponse(
+        drogon::k500InternalServerError, CT_APPLICATION_JSON);
+    resp->setBody(glz::write_json(error).value_or(""));
     callback(resp);
   }
   co_return;
@@ -209,9 +252,10 @@ drogon::Task<> MediaController::get_media_url(
     auto object_key = req->getParameter("object_key");
 
     if (object_key.empty()) {
-      auto resp = drogon::HttpResponse::newHttpResponse();
-      resp->setStatusCode(drogon::k400BadRequest);
-      resp->setBody("object_key is required as a query parameter");
+      SimpleError error{.error = "object_key is required as a query parameter"};
+      auto resp = drogon::HttpResponse::newHttpResponse(drogon::k400BadRequest,
+                                                        CT_APPLICATION_JSON);
+      resp->setBody(glz::write_json(error).value_or(""));
       callback(resp);
       co_return;
     }
@@ -240,23 +284,26 @@ drogon::Task<> MediaController::get_media_url(
 
     if (view_url.empty()) {
       LOG_ERROR << "object url not found";
-      auto resp = drogon::HttpResponse::newHttpResponse();
-      resp->setStatusCode(drogon::k404NotFound);
-      resp->setBody("object url not found");
+      SimpleError error{.error = "object url not found"};
+      auto resp = drogon::HttpResponse::newHttpResponse(drogon::k404NotFound,
+                                                        CT_APPLICATION_JSON);
+      resp->setBody(glz::write_json(error).value_or(""));
       callback(resp);
       co_return;
     }
 
-    Json::Value response;
-    response["download_url"] = view_url;
-    response["content_type"] = content_type;
-    auto resp = drogon::HttpResponse::newHttpJsonResponse(response);
+    GetMediaUrlResponse response{.download_url = view_url,
+                                 .content_type = content_type};
+    auto resp = drogon::HttpResponse::newHttpResponse(drogon::k200OK,
+                                                      CT_APPLICATION_JSON);
+    resp->setBody(glz::write_json(response).value_or(""));
     callback(resp);
   } catch (const std::exception &e) {
     LOG_ERROR << "Failed to get media: " << e.what();
-    auto resp = drogon::HttpResponse::newHttpResponse();
-    resp->setStatusCode(drogon::k500InternalServerError);
-    resp->setBody("Failed to retrieve media");
+    SimpleError error{.error = "Failed to retrieve media"};
+    auto resp = drogon::HttpResponse::newHttpResponse(
+        drogon::k500InternalServerError, CT_APPLICATION_JSON);
+    resp->setBody(glz::write_json(error).value_or(""));
     callback(resp);
   }
   co_return;

--- a/controllers/orders.cc
+++ b/controllers/orders.cc
@@ -12,43 +12,82 @@
 #include <drogon/orm/Row.h>
 #include <drogon/orm/SqlBinder.h>
 
+#include "../utilities/conversion.hpp"
+#include "../utilities/json_manipulation.hpp"
+#include "common_req_n_resp.hpp"
+
 using drogon::app;
+using drogon::CT_APPLICATION_JSON;
 using drogon::HttpRequestPtr;
 using drogon::HttpResponse;
 using drogon::HttpResponsePtr;
 using drogon::k500InternalServerError;
 using drogon::Task;
 using drogon::orm::DrogonDbException;
-using drogon::orm::Transaction;
 
 using api::v1::Orders;
+
+struct OrderInfo {
+  int id;
+  int user_id;
+  std::string status;
+  std::string created_at;
+};
+
+struct CreateOrderRequest {
+  int user_id;
+  std::string status;
+};
+
+struct CreateOrderResponse {
+  std::string status;
+  int order_id;
+};
 
 Task<> Orders::get_orders(
     HttpRequestPtr req, std::function<void(const HttpResponsePtr&)> callback) {
   auto db = app().getDbClient();
 
-  try {
-    auto result =
-        co_await db->execSqlCoro("SELECT * FROM orders ORDER BY id DESC");
+  // Pagination parameters
+  std::size_t page = 1;
+  std::size_t pageSize = 20;
 
-    Json::Value orders{Json::arrayValue};
+  if (!req->getParameter("page").empty()) {
+    page = std::max(
+        1, convert::string_to_int(req->getParameter("page")).value_or(1));
+  }
+  if (!req->getParameter("pageSize").empty()) {
+    pageSize = std::max(
+        1, std::min(100, convert::string_to_int(req->getParameter("pageSize"))
+                             .value_or(20)));
+  }
+  std::size_t offset = (page - 1) * pageSize;
+
+  try {
+    auto result = co_await db->execSqlCoro(
+        "SELECT * FROM orders ORDER BY id DESC LIMIT $1 OFFSET $2", pageSize,
+        offset);
+
+    std::vector<OrderInfo> orders_data;
+    orders_data.reserve(result.size());
     for (const auto& row : result) {
-      Json::Value order;
-      order["id"] = row["id"].as<int>();
-      order["user_id"] = row["user_id"].as<int>();
-      order["status"] = row["status"].as<std::string>();
-      order["created_at"] = row["created_at"].as<std::string>();
-      orders.append(order);
+      orders_data.emplace_back(
+          OrderInfo{.id = row["id"].as<int>(),
+                    .user_id = row["user_id"].as<int>(),
+                    .status = row["status"].as<std::string>(),
+                    .created_at = row["created_at"].as<std::string>()});
     }
 
-    auto resp = HttpResponse::newHttpJsonResponse(orders);
+    auto resp =
+        HttpResponse::newHttpResponse(drogon::k200OK, CT_APPLICATION_JSON);
+    resp->setBody(glz::write_json(orders_data).value_or(""));
     callback(resp);
   } catch (const DrogonDbException& e) {
     LOG_ERROR << "Database error: " << e.base().what();
-    Json::Value error;
-    error["error"] = "Database error";
-    auto resp = HttpResponse::newHttpJsonResponse(error);
-    resp->setStatusCode(k500InternalServerError);
+    SimpleError error{.error = "Database error"};
+    auto resp = HttpResponse::newHttpResponse(k500InternalServerError,
+                                              CT_APPLICATION_JSON);
+    resp->setBody(glz::write_json(error).value_or(""));
     callback(resp);
   }
 
@@ -57,32 +96,46 @@ Task<> Orders::get_orders(
 
 Task<> Orders::create_order(
     HttpRequestPtr req, std::function<void(const HttpResponsePtr&)> callback) {
-  auto json = req->getJsonObject();
-  int user_id = (*json)["user_id"].asInt();
-  std::string status = (*json)["status"].asString();
-
   auto db = app().getDbClient();
+
+  CreateOrderRequest create_req;
+  auto parse_error = utilities::strict_read_json(create_req, req->getBody());
+
+  if (parse_error || create_req.user_id <= 0 || create_req.status.empty()) {
+    SimpleError error{.error = "Invalid JSON or missing fields"};
+    auto resp = HttpResponse::newHttpResponse(drogon::k400BadRequest,
+                                              CT_APPLICATION_JSON);
+    resp->setBody(glz::write_json(error).value_or(""));
+    callback(resp);
+    co_return;
+  }
 
   try {
     auto result = co_await db->execSqlCoro(
         "INSERT INTO orders (user_id, status) VALUES ($1, $2) RETURNING id",
-        user_id, status);
+        create_req.user_id, create_req.status);
 
-    Json::Value ret;
-    ret["status"] = "success";
-    if (!result.empty()) {
-      ret["order_id"] = result[0]["id"].as<int>();
+    if (result.empty()) {
+      SimpleStatus ret{.status = "failed"};
+      auto resp = HttpResponse::newHttpResponse(k500InternalServerError,
+                                                CT_APPLICATION_JSON);
+      resp->setBody(glz::write_json(ret).value_or(""));
+      callback(resp);
+      co_return;
     }
+    CreateOrderResponse response{.status = "success",
+                                 .order_id = result[0]["id"].as<int>()};
 
-    auto resp = HttpResponse::newHttpJsonResponse(ret);
+    auto resp =
+        HttpResponse::newHttpResponse(drogon::k200OK, CT_APPLICATION_JSON);
+    resp->setBody(glz::write_json(response).value_or(""));
     callback(resp);
   } catch (const DrogonDbException& e) {
     LOG_ERROR << "Database error: " << e.base().what();
-    Json::Value ret;
-    ret["status"] = "error";
-    ret["message"] = e.base().what();
-    auto resp = HttpResponse::newHttpJsonResponse(ret);
-    resp->setStatusCode(k500InternalServerError);
+    SimpleError error{.error = e.base().what()};
+    auto resp = HttpResponse::newHttpResponse(k500InternalServerError,
+                                              CT_APPLICATION_JSON);
+    resp->setBody(glz::write_json(error).value_or(""));
     callback(resp);
   }
 

--- a/controllers/scenario_specific_utils.hpp
+++ b/controllers/scenario_specific_utils.hpp
@@ -5,10 +5,14 @@
 #include <drogon/orm/DbClient.h>
 
 #include "../services/service_manager.hpp"
+#include "../utilities/json_manipulation.hpp"
+#include "common_req_n_resp.hpp"
 
 /**
+ * @note
  * Assumptions for quick_process_media_attachments, process_media_attachments
- * and get_media_attachments,
+ * process_media_attachments_with_response,
+ * get_media_attachments and get_media_attachments_with_response,
  * media db tables have the following structure:
  * table name - "prefix"_media e.g. offer_media, post_media, message_media
  * table prefix id - "prefix"_id e.g. offer_id, post_id, message_id
@@ -21,40 +25,27 @@
  * It runs using an existing db transaction.
  * Processing involves checks for validity of object key making necessary
  * media attachment inserts.
- * @return boolean.
- * false means there was an error,
- * returns true if processing is successful even if it didn't process all.
+ * @return boolean. false means there was an error,
+ * true if processing is successful even if it didn't process all.
  */
 inline drogon::Task<bool> quick_process_media_attachments(
-    Json::Value&& media_array,
+    std::vector<std::string>&& object_keys,
     const std::shared_ptr<drogon::orm::Transaction>& transaction,
-    int current_user_id, std::string media_table_prefix,
-    int media_table_prefix_id) {
-  if (!media_array.isArray()) {
-    co_return false;
-  };
-
-  for (const auto& media_item : media_array) {
-    if (!media_item.isString()) {
-      LOG_WARN << "Invalid media item format, skipping";
-      continue;
-    }
-
-    std::string storage_key = media_item.asString();
-
+    std::string current_user_id, std::string media_table_prefix,
+    std::string media_table_prefix_id) {
+  for (const auto& object_key : object_keys) {
     MediaInfo info =
         co_await ServiceManager::get_instance().get_s3_service().get_media_info(
-            "media", storage_key);
+            service::BUCKET_NAME, object_key);
     if (info.etag.empty()) {
-      LOG_ERROR << "Media info not found for " << storage_key;
+      LOG_ERROR << "Media info not found for " << object_key;
       continue;
     }
 
-    std::string file_name = storage_key.substr(storage_key.find('_') + 1);
+    std::string file_name = object_key.substr(object_key.find('_') + 1);
     std::string mime_type = !info.content_type.empty()
                                 ? info.content_type
                                 : "application/octet-stream";
-    int64_t size = info.content_length;
 
     auto media_result = co_await transaction->execSqlCoro(
         "INSERT INTO media (uploader_id, storage_key, file_name, "
@@ -65,7 +56,7 @@ inline drogon::Task<bool> quick_process_media_attachments(
         "mime_type = EXCLUDED.mime_type, "
         "size = EXCLUDED.size "
         "RETURNING id",
-        current_user_id, storage_key, file_name, mime_type, size);
+        current_user_id, object_key, file_name, mime_type, info.content_length);
 
     if (!media_result.empty()) {
       int media_id = media_result[0]["id"].as<int>();
@@ -84,149 +75,334 @@ inline drogon::Task<bool> quick_process_media_attachments(
  * It runs using an existing db transaction.
  * Processing involves checks for validity of object key making necessary
  * media attachment inserts.
- * @return Json::Value. Error is represented as a Json::nullValue.
- * If the some media is valid, a Json::arrayValue containing the processed
- * media info is returned.
- * Parameters passed by value/moved to avoid dangling references.
+ * @return std::vector<MediaQuickInfo> containing the fetched media
+ * if successful or an error string.
+ * @note Parameters passed by value/moved to avoid dangling references.
  */
-inline drogon::Task<Json::Value> process_media_attachments(
-    Json::Value&& media_array,
+inline drogon::Task<std::expected<std::vector<MediaQuickInfo>, std::string>>
+process_media_attachments(
+    std::vector<std::string>&& object_keys,
     const std::shared_ptr<drogon::orm::Transaction>& transaction,
     int current_user_id, std::string media_table_prefix,
     int media_table_prefix_id) {
-  if (!media_array.isArray()) {
-    co_return Json::nullValue;
-  };
+  try {
+    std::vector<MediaQuickInfo> processed_media;
+    processed_media.reserve(object_keys.size());
+    for (const auto& object_key : object_keys) {
+      MediaInfo info = co_await ServiceManager::get_instance()
+                           .get_s3_service()
+                           .get_media_info(service::BUCKET_NAME, object_key);
+      if (info.etag.empty()) {
+        continue;
+      }
 
-  Json::Value processed_media(Json::arrayValue);
+      std::string filename = object_key.substr(object_key.find('_') + 1);
+      std::string mime_type = !info.content_type.empty()
+                                  ? info.content_type
+                                  : "application/octet-stream";
+      int64_t& size = info.content_length;
 
-  for (const auto& media_item : media_array) {
-    if (!media_item.isString()) {
-      LOG_WARN << "Invalid media item format, skipping";
-      continue;
+      auto media_result = co_await transaction->execSqlCoro(
+          "INSERT INTO media (uploader_id, storage_key, file_name, "
+          "mime_type, size) "
+          "VALUES ($1, $2, $3, $4, $5) "
+          "ON CONFLICT (storage_key) DO UPDATE SET "
+          "file_name = EXCLUDED.file_name, "
+          "mime_type = EXCLUDED.mime_type, "
+          "size = EXCLUDED.size "
+          "RETURNING id",
+          current_user_id, object_key, filename, mime_type, size);
+
+      if (!media_result.empty()) {
+        auto media_id = media_result[0]["id"].as<int>();
+        std::string query = std::format(
+            "INSERT INTO {}_media ({}_id, media_id) VALUES ($1, $2)",
+            media_table_prefix, media_table_prefix);
+        // Link media to particular table
+        co_await transaction->execSqlCoro(query, media_table_prefix_id,
+                                          media_id);
+
+        processed_media.emplace_back(MediaQuickInfo{.media_id = media_id,
+                                                    .object_key = object_key,
+                                                    .filename = filename,
+                                                    .mime_type = mime_type,
+                                                    .size = size});
+
+        // Alternatively Generate presigned URL for viewing
+        // try {
+        //   auto presigned_url = co_await ServiceManager::get_instance()
+        //                         .get_s3_service()
+        //                         .generate_presigned_url(service::BUCKET_NAME,
+        //                         object_key,
+        //                         drogon::HttpMethod::Get,
+        //                         mime_type);
+        //   processed_media.emplace_back(MediaQuickInfo{.media_id = media_id,
+        //       .object_key = object_key,
+        //       .filename = filename,
+        //       .mime_type = mime_type,
+        //       .size = size,
+        //       .presigned_url = presigned_url});
+        // } catch (const std::exception& e) {
+        //   LOG_ERROR << "Failed to generate presigned URL: " << e.what();
+        // processed_media.emplace_back(MediaQuickInfo{.media_id = media_id,
+        //                                             .object_key = object_key,
+        //                                             .filename = filename,
+        //                                             .mime_type = mime_type,
+        //                                             .size = size});
+        // }
+      }
     }
+    co_return processed_media;
 
-    std::string storage_key = media_item.asString();
-    MediaInfo info =
-        co_await ServiceManager::get_instance().get_s3_service().get_media_info(
-            "media", storage_key);
-    if (info.etag.empty()) {
-      LOG_ERROR << "Media info not found for " << storage_key;
-      continue;
-    }
-
-    std::string file_name = storage_key.substr(storage_key.find('_') + 1);
-    std::string mime_type = !info.content_type.empty()
-                                ? info.content_type
-                                : "application/octet-stream";
-    int64_t size = info.content_length;
-
-    auto media_result = co_await transaction->execSqlCoro(
-        "INSERT INTO media (uploader_id, storage_key, file_name, "
-        "mime_type, size) "
-        "VALUES ($1, $2, $3, $4, $5) "
-        "ON CONFLICT (storage_key) DO UPDATE SET "
-        "file_name = EXCLUDED.file_name, "
-        "mime_type = EXCLUDED.mime_type, "
-        "size = EXCLUDED.size "
-        "RETURNING id",
-        current_user_id, storage_key, file_name, mime_type, size);
-
-    if (!media_result.empty()) {
-      int media_id = media_result[0]["id"].as<int>();
-      std::string query =
-          std::format("INSERT INTO {}_media ({}_id, media_id) VALUES ($1, $2)",
-                      media_table_prefix, media_table_prefix);
-      // Link media to particular table
-      co_await transaction->execSqlCoro(query, media_table_prefix_id, media_id);
-
-      Json::Value processed_item;
-      processed_item["id"] = media_id;
-      processed_item["storage_key"] = storage_key;
-      processed_item["file_name"] = file_name;
-      processed_item["mime_type"] = mime_type;
-      processed_item["size"] = size;
-
-      // Alternatively Generate presigned URL for viewing
-      // try {
-      //   auto presigned_url = co_await ServiceManager::get_instance()
-      //                            .get_s3_service()
-      //                            .generate_presigned_url("media",
-      //                            storage_key,
-      //                            drogon::HttpMethod::Get,
-      //                            mime_type);
-      //   processed_item["presigned_url"] = presigned_url;
-      // } catch (const std::exception& e) {
-      //   LOG_ERROR << "Failed to generate presigned URL: " << e.what();
-      //   processed_item["presigned_url"] = "";
-      // }
-
-      processed_media.append(processed_item);
-    }
+  } catch (const drogon::orm::DrogonDbException& e) {
+    LOG_ERROR << "Database error: " << e.base().what();
+    co_return std::unexpected(e.base().what());
+  } catch (const std::exception& e) {
+    LOG_ERROR << "Database error: " << e.what();
+    co_return std::unexpected(e.what());
   }
-  co_return processed_media;
+}
+
+/**
+ * @brief Full processing of available media and continues the response.
+ * It runs using an existing db transaction.
+ * It checks for validity of object key, does necessary media attachment
+ * inserts and return a response to client.
+ * @note Parameters passed by value/moved to avoid dangling references.
+ * This is more efficient for processing only operations.
+ */
+inline drogon::Task<> process_media_attachments_with_response(
+    std::function<void(const drogon::HttpResponsePtr&)> callback,
+    std::vector<std::string>&& object_keys,
+    const std::shared_ptr<drogon::orm::Transaction>& transaction,
+    std::string current_user_id, std::string media_table_prefix,
+    std::string media_table_prefix_id) {
+  try {
+    MediaResponse media_resp;
+    media_resp.media_ids.reserve(object_keys.size());
+    auto& processed_media = media_resp.media_ids;
+    for (const auto& object_key : object_keys) {
+      MediaInfo info = co_await ServiceManager::get_instance()
+                           .get_s3_service()
+                           .get_media_info(service::BUCKET_NAME, object_key);
+      if (info.etag.empty()) {
+        continue;
+      }
+
+      std::string filename = object_key.substr(object_key.find('_') + 1);
+      std::string mime_type = !info.content_type.empty()
+                                  ? info.content_type
+                                  : "application/octet-stream";
+      int64_t& size = info.content_length;
+
+      auto media_result = co_await transaction->execSqlCoro(
+          "INSERT INTO media (uploader_id, storage_key, file_name, "
+          "mime_type, size) "
+          "VALUES ($1, $2, $3, $4, $5) "
+          "ON CONFLICT (storage_key) DO UPDATE SET "
+          "file_name = EXCLUDED.file_name, "
+          "mime_type = EXCLUDED.mime_type, "
+          "size = EXCLUDED.size "
+          "RETURNING id",
+          current_user_id, object_key, filename, mime_type, size);
+
+      if (!media_result.empty()) {
+        auto media_id = media_result[0]["id"].as<int>();
+        std::string query = std::format(
+            "INSERT INTO {}_media ({}_id, media_id) VALUES ($1, $2)",
+            media_table_prefix, media_table_prefix);
+        // Link media to particular table
+        co_await transaction->execSqlCoro(query, media_table_prefix_id,
+                                          media_id);
+
+        processed_media.emplace_back(media_id);
+      }
+    }
+
+    if (processed_media.size() < object_keys.size()) {
+      LOG_ERROR << " Some Media info was not found";
+      transaction->rollback();
+      std::string error_string;
+      for (const auto& name : processed_media) {
+        error_string += std::format("{},", name);
+      }
+      SimpleError error{.error =
+                            std::format("Media info not found or processed, "
+                                        "only the following media items "
+                                        "were processed:\n{}",
+                                        error_string)};
+      auto resp = drogon::HttpResponse::newHttpResponse(
+          drogon::k400BadRequest, drogon::CT_APPLICATION_JSON);
+      resp->setBody(glz::write_json(error).value_or(""));
+      callback(resp);
+      co_return;
+    }
+
+    auto resp = drogon::HttpResponse::newHttpResponse(
+        drogon::k200OK, drogon::CT_APPLICATION_JSON);
+    resp->setBody(glz::write_json(media_resp).value_or(""));
+    callback(resp);
+    co_return;
+
+  } catch (const drogon::orm::DrogonDbException& e) {
+    LOG_ERROR << "Database error: " << e.base().what();
+    SimpleError error{.error = "error during processing"};
+    auto resp = drogon::HttpResponse::newHttpResponse(
+        drogon::k500InternalServerError, drogon::CT_APPLICATION_JSON);
+    resp->setBody(glz::write_json(error).value_or(""));
+    callback(resp);
+    co_return;
+  } catch (const std::exception& e) {
+    LOG_ERROR << "Error: " << e.what();
+    SimpleError error{.error = "error during processing"};
+    auto resp = drogon::HttpResponse::newHttpResponse(
+        drogon::k500InternalServerError, drogon::CT_APPLICATION_JSON);
+    resp->setBody(glz::write_json(error).value_or(""));
+    callback(resp);
+    co_return;
+  }
 }
 
 /**
  * @brief Fetches available media.
  * It runs using an existing db transaction.
- * @return Json::Value.
- * Error is represented as a Json::nullValue.
- * If the some media is valid, a Json::arrayValue containing the fetched media.
- * Parameters passed by value to avoid dangling references.
+ * @return std::vector<MediaQuickInfo> containing the fetched media
+ * if successful or an error string.
+ * @note Parameters passed by value to avoid dangling references.
  */
-inline drogon::Task<Json::Value> get_media_attachments(
-    std::string media_table_prefix, int media_table_prefix_id) {
+inline drogon::Task<std::expected<std::vector<MediaQuickInfo>, std::string>>
+get_media_attachments(std::string media_table_prefix,
+                      int media_table_prefix_id) {
   auto db = drogon::app().getDbClient();
-  auto media_result = co_await db->execSqlCoro(
-      std::format(
-          "SELECT med.id, med.storage_key, med.file_name, med.mime_type, "
-          "med.size, med.metadata "
-          "FROM {}_media om "
-          "JOIN media med ON om.media_id = med.id "
-          "WHERE om.{}_id = $1",
-          media_table_prefix, media_table_prefix),
-      media_table_prefix_id);
+  try {
+    auto media_result = co_await db->execSqlCoro(
+        std::format(
+            "SELECT med.id, med.storage_key, med.file_name, med.mime_type, "
+            "med.size, med.metadata "
+            "FROM {}_media om "
+            "INNER JOIN media med ON om.media_id = med.id "
+            "WHERE om.{}_id = $1",  // ORDER BY med.created_at DESC
+            media_table_prefix, media_table_prefix),
+        media_table_prefix_id);
 
-  if (!media_result.empty()) {
-    Json::Value media_array(Json::arrayValue);
+    std::vector<MediaQuickInfo> media_array;
+    if (!media_result.empty()) {
+      media_array.reserve(media_result.size());
 
-    for (const auto& media_row : media_result) {
-      Json::Value media_item;
-      media_item["id"] = media_row["id"].as<int>();
-      media_item["object_key"] = media_row["storage_key"].as<std::string>();
-      media_item["file_name"] = media_row["file_name"].as<std::string>();
-      media_item["mime_type"] = media_row["mime_type"].as<std::string>();
-      media_item["size"] = media_row["size"].as<int64_t>();
+      for (const auto& media_row : media_result) {
+        media_array.emplace_back(MediaQuickInfo{
+            .media_id = media_row["id"].as<int>(),
+            .object_key = media_row["storage_key"].as<std::string>(),
+            .filename = media_row["file_name"].as<std::string>(),
+            .mime_type = media_row["mime_type"].as<std::string>(),
+            .size = media_row["size"].as<int64_t>()});
+        // alternatively Generate presigned URL for viewing
+        // std::string object_key =
+        // media_row["storage_key"].as<std::string>();
+        // std::string mime_type = media_row["mime_type"].as<std::string>();
 
-      // alternatively Generate presigned URL for viewing
-      // std::string storage_key =
-      // media_row["storage_key"].as<std::string>(); std::string mime_type =
-      // media_row["mime_type"].as<std::string>();
-
-      // try {
-      //   auto presigned_url = co_await ServiceManager::get_instance()
-      //                            .get_s3_service()
-      //                            .generate_presigned_url("media",
-      //                            storage_key,
-      //                            drogon::HttpMethod::Get,
-      //                            mime_type);
-      //   media_item["presigned_url"] = presigned_url;
-      // } catch (const std::exception& e) {
-      //   LOG_ERROR << "Failed to generate presigned URL: " << e.what();
-      //   media_item["presigned_url"] = "";
-      // }
-
-      if (!media_row["metadata"].isNull()) {
-        media_item["metadata"] = media_row["metadata"].as<std::string>();
+        // try {
+        //   auto presigned_url = co_await ServiceManager::get_instance()
+        //                        .get_s3_service()
+        //                        .generate_presigned_url(service::BUCKET_NAME,
+        //                         object_key,
+        //                         drogon::HttpMethod::Get,
+        //                         mime_type);
+        //   media_item["presigned_url"] = presigned_url;
+        // } catch (const std::exception& e) {
+        //   LOG_ERROR << "Failed to generate presigned URL: " << e.what();
+        //   media_item["presigned_url"] = "";
+        // }
       }
-
-      media_array.append(media_item);
     }
-
     co_return media_array;
+  } catch (const drogon::orm::DrogonDbException& e) {
+    LOG_ERROR << std::format("Database error: getting {} media: {}",
+                             media_table_prefix, e.base().what());
+    co_return std::unexpected(e.base().what());
+  } catch (const std::exception& e) {
+    LOG_ERROR << std::format("Error getting {} media: {}", media_table_prefix,
+                             e.what());
+    co_return std::unexpected(e.what());
   }
-  co_return Json::nullValue;
+}
+
+/**
+ * @brief Fetches available media and continues the response.
+ * It runs using an existing db transaction.
+ * @return std::vector<MediaQuickInfo> containing the fetched media
+ * if successful or an error string.
+ * @note Parameters passed by value to avoid dangling references.
+ */
+inline drogon::Task<> get_media_attachments_with_response(
+    std::function<void(const drogon::HttpResponsePtr&)> callback,
+    std::string media_table_prefix, std::string media_table_prefix_id) {
+  auto db = drogon::app().getDbClient();
+  try {
+    auto media_result = co_await db->execSqlCoro(
+        std::format(
+            "SELECT med.id, med.storage_key, med.file_name, med.mime_type, "
+            "med.size, med.metadata "
+            "FROM {}_media om "
+            "INNER JOIN media med ON om.media_id = med.id "
+            "WHERE om.{}_id = $1",  // ORDER BY med.created_at DESC
+            media_table_prefix, media_table_prefix),
+        media_table_prefix_id);
+    MediaInfoResponse media_resp;
+    if (!media_result.empty()) {
+      auto& media_array = media_resp.media;
+      media_array.reserve(media_result.size());
+
+      for (const auto& media_row : media_result) {
+        media_array.emplace_back(MediaQuickInfo{
+            .media_id = media_row["id"].as<int>(),
+            .object_key = media_row["storage_key"].as<std::string>(),
+            .filename = media_row["file_name"].as<std::string>(),
+            .mime_type = media_row["mime_type"].as<std::string>(),
+            .size = media_row["size"].as<int64_t>()});
+        // alternatively Generate presigned URL for viewing
+        // std::string object_key =
+        // media_row["storage_key"].as<std::string>();
+        // std::string mime_type = media_row["mime_type"].as<std::string>();
+
+        // try {
+        //   auto presigned_url = co_await ServiceManager::get_instance()
+        //                        .get_s3_service()
+        //                        .generate_presigned_url(service::BUCKET_NAME,
+        //                         object_key,
+        //                         drogon::HttpMethod::Get,
+        //                         mime_type);
+        //   media_item["presigned_url"] = presigned_url;
+        // } catch (const std::exception& e) {
+        //   LOG_ERROR << "Failed to generate presigned URL: " << e.what();
+        //   media_item["presigned_url"] = "";
+        // }
+      }
+    }
+    auto resp = drogon::HttpResponse::newHttpResponse(
+        drogon::k200OK, drogon::CT_APPLICATION_JSON);
+    resp->setBody(glz::write_json(media_resp).value_or(""));
+    callback(resp);
+    co_return;
+  } catch (const drogon::orm::DrogonDbException& e) {
+    LOG_ERROR << std::format("Database error: getting {} media: {}",
+                             media_table_prefix, e.base().what());
+    SimpleError error{.error = "error during fetch"};
+    auto resp = drogon::HttpResponse::newHttpResponse(
+        drogon::k500InternalServerError, drogon::CT_APPLICATION_JSON);
+    resp->setBody(glz::write_json(error).value_or(""));
+    callback(resp);
+    co_return;
+  } catch (const std::exception& e) {
+    LOG_ERROR << std::format("Error getting {} media: {}", media_table_prefix,
+                             e.what());
+    SimpleError error{.error = "error during fetch"};
+    auto resp = drogon::HttpResponse::newHttpResponse(
+        drogon::k500InternalServerError, drogon::CT_APPLICATION_JSON);
+    resp->setBody(glz::write_json(error).value_or(""));
+    callback(resp);
+    co_return;
+  }
 }
 
 #endif  // SCENARIO_SPECIFIC_UTILS_HPP

--- a/controllers/search.cc
+++ b/controllers/search.cc
@@ -12,83 +12,116 @@
 #include <drogon/orm/Row.h>
 #include <drogon/orm/SqlBinder.h>
 
+#include "../utilities/conversion.hpp"
+#include "../utilities/json_manipulation.hpp"
+#include "common_req_n_resp.hpp"
+
 using drogon::app;
+using drogon::CT_APPLICATION_JSON;
 using drogon::HttpResponse;
 using drogon::HttpResponsePtr;
 using drogon::orm::DrogonDbException;
-using drogon::orm::Transaction;
 
 using api::v1::Search;
+struct SearchResultItem {
+  int id;
+  std::string type;
+  std::string details;
+};
 
 drogon::Task<> Search::search(
     drogon::HttpRequestPtr req,
     std::function<void(const drogon::HttpResponsePtr&)> callback) {
   auto query = req->getParameter("query");
+  std::size_t page = 1;
+  std::size_t pageSize = 20;
 
-  LOG_DEBUG << "Search query received: '" << query << "'";
+  // Parse pagination parameters safely
+  if (req->getParameter("page").empty() == false) {
+    page = std::max(
+        1, convert::string_to_int(req->getParameter("page")).value_or(1));
+  }
+
+  if (req->getParameter("pageSize").empty() == false) {
+    pageSize = std::max(
+        1, std::min(100, convert::string_to_int(req->getParameter("pageSize"))
+                             .value_or(20)));
+  }
+
+  std::size_t offset = (page - 1) * pageSize;
+
+  LOG_DEBUG << "Search query received: '" << query << "', page: " << page
+            << ", pageSize: " << pageSize;
 
   // return empty results for empty query
   if (query.empty()) {
-    Json::Value empty_results = Json::Value(Json::arrayValue);
-    auto resp = HttpResponse::newHttpJsonResponse(empty_results);
+    std::vector<SearchResultItem> empty_results = {};
+    auto resp =
+        HttpResponse::newHttpResponse(drogon::k200OK, CT_APPLICATION_JSON);
+    resp->setBody(glz::write_json(empty_results).value_or(""));
     callback(resp);
     co_return;
   }
 
   auto db = app().getDbClient();
   try {
-    // Search orders
+    // Use parameterized queries to prevent SQL injection
     auto orders_result = co_await db->execSqlCoro(
         "SELECT * FROM orders WHERE CAST(id AS TEXT) ILIKE $1 OR status ILIKE "
-        "$1",
-        "%" + query + "%");
+        "$1 ORDER BY id DESC LIMIT $2 OFFSET $3",
+        "%" + query + "%", pageSize, offset);
 
-    Json::Value search_results = Json::Value(Json::arrayValue);
+    std::vector<SearchResultItem> search_results_data;
+    search_results_data.reserve(orders_result.size());
 
     LOG_DEBUG << "Found " << orders_result.size()
               << " matching orders for query: '" << query << "'";
 
     for (const auto& row : orders_result) {
-      Json::Value order;
-      order["id"] = row["id"].as<int>();
-      order["type"] = "Order";
-      order["details"] = "Order #" + row["id"].as<std::string>() + " - " +
-                         row["status"].as<std::string>();
-      search_results.append(order);
+      search_results_data.emplace_back(
+          SearchResultItem{.id = row["id"].as<int>(),
+                           .type = "Order",
+                           .details = "Order #" + row["id"].as<std::string>() +
+                                      " - " + row["status"].as<std::string>()});
     }
 
     try {
-      // Also search posts
       auto posts_result = co_await db->execSqlCoro(
-          "SELECT * FROM posts WHERE content ILIKE $1", "%" + query + "%");
+          "SELECT * FROM posts WHERE content ILIKE $1 ORDER BY id DESC LIMIT "
+          "$2 OFFSET $3",
+          "%" + query + "%", pageSize, offset);
 
       LOG_DEBUG << "Found " << posts_result.size()
                 << " matching posts for query: '" << query << "'";
-
+      search_results_data.reserve(orders_result.size() + posts_result.size());
       for (const auto& row : posts_result) {
-        Json::Value post;
-        post["id"] = row["id"].as<int>();
-        post["type"] = "Post";
         std::string content = row["content"].as<std::string>();
-        post["details"] =
-            "Post: " +
-            (content.length() > 50 ? content.substr(0, 50) + "..." : content);
-        search_results.append(post);
+        search_results_data.emplace_back(SearchResultItem{
+            .id = row["id"].as<int>(),
+            .type = "Post",
+            .details = "Post: " + (content.length() > 50
+                                       ? content.substr(0, 50) + "..."
+                                       : content)});
       }
 
-      // Prepare response
-      auto resp = HttpResponse::newHttpJsonResponse(search_results);
+      auto resp =
+          HttpResponse::newHttpResponse(drogon::k200OK, CT_APPLICATION_JSON);
+      resp->setBody(glz::write_json(search_results_data).value_or(""));
       callback(resp);
     } catch (const DrogonDbException& e) {
       LOG_ERROR << "Database error searching posts: " << e.base().what();
       // Still return the order results even if post search fails
-      auto resp = HttpResponse::newHttpJsonResponse(search_results);
+      auto resp =
+          HttpResponse::newHttpResponse(drogon::k200OK, CT_APPLICATION_JSON);
+      resp->setBody(glz::write_json(search_results_data).value_or(""));
       callback(resp);
     }
   } catch (const DrogonDbException& e) {
     LOG_ERROR << "Database error searching orders: " << e.base().what();
-    Json::Value empty_results = Json::Value(Json::arrayValue);
-    auto resp = HttpResponse::newHttpJsonResponse(empty_results);
+    SimpleError error{.error = "Database error"};
+    auto resp = HttpResponse::newHttpResponse(drogon::k500InternalServerError,
+                                              CT_APPLICATION_JSON);
+    resp->setBody(glz::write_json(error).value_or(""));
     callback(resp);
   }
 

--- a/controllers/search.cc
+++ b/controllers/search.cc
@@ -36,7 +36,6 @@ drogon::Task<> Search::search(
   std::size_t page = 1;
   std::size_t pageSize = 20;
 
-  // Parse pagination parameters safely
   if (req->getParameter("page").empty() == false) {
     page = std::max(
         1, convert::string_to_int(req->getParameter("page")).value_or(1));
@@ -65,7 +64,6 @@ drogon::Task<> Search::search(
 
   auto db = app().getDbClient();
   try {
-    // Use parameterized queries to prevent SQL injection
     auto orders_result = co_await db->execSqlCoro(
         "SELECT * FROM orders WHERE CAST(id AS TEXT) ILIKE $1 OR status ILIKE "
         "$1 ORDER BY id DESC LIMIT $2 OFFSET $3",

--- a/controllers/users.cc
+++ b/controllers/users.cc
@@ -12,40 +12,70 @@
 #include <drogon/orm/Row.h>
 #include <drogon/orm/SqlBinder.h>
 
+#include "../utilities/conversion.hpp"
+#include "../utilities/json_manipulation.hpp"
+#include "common_req_n_resp.hpp"
+
+
 using drogon::app;
+using drogon::CT_APPLICATION_JSON;
 using drogon::HttpResponse;
-using drogon::k500InternalServerError;
-using drogon::orm::DrogonDbException;
 
 using api::v1::Users;
+
+struct UserInfo {
+  int id;
+  std::string username;
+  std::string email;
+  std::string created_at;
+};
 
 drogon::Task<> Users::get_users(
     drogon::HttpRequestPtr req,
     std::function<void(const drogon::HttpResponsePtr&)> callback) {
   auto db = app().getDbClient();
 
+  std::size_t page = 1;
+  std::size_t pageSize = 20;
+
+  // Parse pagination parameters safely
+  if (!req->getParameter("page").empty()) {
+    page = std::max(
+        1, convert::string_to_int(req->getParameter("page")).value_or(1));
+  }
+  if (!req->getParameter("pageSize").empty()) {
+    pageSize = std::max(
+        1, std::min(100, convert::string_to_int(req->getParameter("pageSize"))
+                             .value_or(20)));
+  }
+  std::size_t offset = (page - 1) * pageSize;
+
   try {
     auto result = co_await db->execSqlCoro(
-        "SELECT id, username, email, created_at FROM users ORDER BY username");
+        "SELECT id, username, email, created_at FROM users ORDER BY username "
+        "LIMIT $1 OFFSET $2",
+        pageSize, offset);
 
-    Json::Value users;
+    std::vector<UserInfo> users_data;
+    users_data.reserve(result.size());
     for (const auto& row : result) {
-      Json::Value user;
-      user["id"] = row["id"].as<int>();
-      user["username"] = row["username"].as<std::string>();
-      user["email"] = row["email"].as<std::string>();
-      user["created_at"] = row["created_at"].as<std::string>();
-      users.append(user);
+      users_data.emplace_back(
+          UserInfo{.id = row["id"].as<int>(),
+                   .username = row["username"].as<std::string>(),
+                   .email = row["email"].as<std::string>(),
+                   .created_at = row["created_at"].as<std::string>()});
     }
 
-    auto resp = HttpResponse::newHttpJsonResponse(users);
+    auto resp =
+        HttpResponse::newHttpResponse(drogon::k200OK, CT_APPLICATION_JSON);
+    resp->setBody(glz::write_json(users_data).value_or(""));
     callback(resp);
-  } catch (const DrogonDbException& e) {
+  } catch (const drogon::orm::DrogonDbException& e) {
     LOG_ERROR << "Database error: " << e.base().what();
-    Json::Value error;
-    error["error"] = "Database error";
-    auto resp = HttpResponse::newHttpJsonResponse(error);
-    resp->setStatusCode(k500InternalServerError);
+    SimpleError error{.error = "Database error"};
+    auto resp = HttpResponse::newHttpResponse(drogon::k500InternalServerError,
+                                              CT_APPLICATION_JSON);
+    resp->setBody(glz::write_json(error).value_or(""));
     callback(resp);
   }
 

--- a/controllers/users.hpp
+++ b/controllers/users.hpp
@@ -1,10 +1,10 @@
-#pragma once
+#ifndef USERS_HPP
+#define USERS_HPP
 
 #include <drogon/HttpController.h>
 
 namespace api {
 namespace v1 {
-
 class Users : public drogon::HttpController<Users> {
  public:
   METHOD_LIST_BEGIN
@@ -19,3 +19,5 @@ class Users : public drogon::HttpController<Users> {
 
 }  // namespace v1
 }  // namespace api
+
+#endif  // USERS_HPPs

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,0 +1,48 @@
+version: '3.8'
+
+services:
+  # Test PostgreSQL Database (Non-persistent)
+  postgres-test:
+    image: postgis/postgis:18-3.6-alpine
+    container_name: buyer-backend-postgres-test
+    environment:
+      POSTGRES_DB: buyer_app_test
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: mypassword
+      POSTGRES_HOST_AUTH_METHOD: trust
+    ports:
+      - "5433:5432"
+    volumes:
+      - ./migrations/001_complete_schema.sql:/docker-entrypoint-initdb.d/001_complete_schema.sql:ro
+      - ./seeds/001_complete_seed_data.sql:/docker-entrypoint-initdb.d/001_complete_seed_data.sql:ro
+    networks:
+      - buyer-backend-network-test
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres -d buyer_app_test"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    restart: unless-stopped
+  minio-test:
+    image: minio/minio:latest
+    container_name: buyer-backend-minio-test
+    command: server /data --console-address ":9001"
+    environment:
+      MINIO_ROOT_USER: minioadmin
+      MINIO_ROOT_PASSWORD: mypassword
+    ports:
+      - "9002:9000"
+      - "9003:9001"
+    volumes:
+      - .volumes/minio-data:/data
+    networks:
+      - buyer-backend-network-test
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
+      interval: 30s
+      timeout: 20s
+      retries: 3
+    restart: unless-stopped
+networks:
+  buyer-backend-network-test:
+    driver: bridge

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,8 @@
 version: '3.8'
 
 services:
-  # Main PostgreSQL Database (Persistent)
   postgres-main:
-    image: postgis/postgis:17-3.4
+    image: postgis/postgis:18-3.6-alpine
     container_name: buyer-backend-postgres-main
     environment:
       POSTGRES_DB: agentbackend
@@ -23,38 +22,13 @@ services:
       timeout: 5s
       retries: 5
     restart: unless-stopped
-
-  # Test PostgreSQL Database (Non-persistent)
-  postgres-test:
-    image: postgis/postgis:17-3.4
-    container_name: buyer-backend-postgres-test
-    environment:
-      POSTGRES_DB: buyer_app_test
-      POSTGRES_USER: postgres
-      POSTGRES_PASSWORD: mypassword
-      POSTGRES_HOST_AUTH_METHOD: trust
-    ports:
-      - "5433:5432"
-    volumes:
-      - ./migrations/001_complete_schema.sql:/docker-entrypoint-initdb.d/001_complete_schema.sql:ro
-      - ./seeds/001_complete_seed_data.sql:/docker-entrypoint-initdb.d/001_complete_seed_data.sql:ro
-    networks:
-      - buyer-backend-network
-    healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U postgres -d buyer_app_test"]
-      interval: 10s
-      timeout: 5s
-      retries: 5
-    restart: unless-stopped
-
-  # MinIO Object Storage
   minio:
     image: minio/minio:latest
     container_name: buyer-backend-minio
     command: server /data --console-address ":9001"
     environment:
       MINIO_ROOT_USER: minioadmin
-      MINIO_ROOT_PASSWORD: password
+      MINIO_ROOT_PASSWORD: mypassword
     ports:
       - "9000:9000"
       - "9001:9001"

--- a/services/media_server/s3_service.cpp
+++ b/services/media_server/s3_service.cpp
@@ -150,7 +150,7 @@ drogon::Task<bool> S3Service::ensure_bucket_exists(
 }
 
 drogon::Task<MediaInfo> S3Service::get_media_info(
-    const std::string &bucket_name, const std::string &object_key) {
+    std::string_view bucket_name, const std::string &object_key) {
   Aws::S3::Model::HeadObjectRequest head_request;
   head_request.SetBucket(bucket_name);
   head_request.SetKey(object_key);

--- a/services/media_server/s3_service.hpp
+++ b/services/media_server/s3_service.hpp
@@ -34,7 +34,7 @@ class S3Service {
   // Ensures a bucket exists, creating it if necessary
   drogon::Task<bool> ensure_bucket_exists(const std::string& bucket_name);
 
-  drogon::Task<MediaInfo> get_media_info(const std::string& bucket_name,
+  drogon::Task<MediaInfo> get_media_info(std::string_view bucket_name,
                                          const std::string& object_key);
 
   Aws::S3::S3Client* get_client() { return s3_client_.get(); }

--- a/services/service_manager.hpp
+++ b/services/service_manager.hpp
@@ -12,9 +12,10 @@
 // Redis PubSub option: noticed instability with large number of subscriptions
 // #include "./subber/redis_pub_manager.hpp"
 // #include "./subber/redis_sub_manager.hpp"
-
+namespace service {
+inline constexpr std::string_view BUCKET_NAME = "media";
 inline constexpr std::uint32_t MAX_MEDIA_SIZE = 5U;
-
+}  // namespace service
 class ServiceManager {
  public:
   static ServiceManager& get_instance() {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -24,12 +24,12 @@ add_executable(${PROJECT_NAME}
 target_link_libraries(${PROJECT_NAME} PRIVATE Drogon::Drogon)
 
 # Custom target to configure tests with a fresh database
-# comment out if you are using docker compose !!!
-add_custom_target(configure_tests
-    COMMAND ${CMAKE_COMMAND} --build ${CMAKE_BINARY_DIR} --target setup_test_db
-    COMMAND ${CMAKE_COMMAND} --build ${CMAKE_BINARY_DIR} --target ${PROJECT_NAME}
-    COMMENT "Setting up test database and running tests"
-)
+# if not using docker and you have postgres installed locally !!!
+# add_custom_target(configure_tests
+#     COMMAND ${CMAKE_COMMAND} --build ${CMAKE_BINARY_DIR} --target setup_test_db
+#     COMMAND ${CMAKE_COMMAND} --build ${CMAKE_BINARY_DIR} --target ${PROJECT_NAME}
+#     COMMENT "Setting up test database and running tests"
+# )
 
 ParseAndAddDrogonTests(${PROJECT_NAME})
 

--- a/test/test_authentication.cc
+++ b/test/test_authentication.cc
@@ -25,7 +25,7 @@ DROGON_TEST(AuthenticationTest) {
   REQUIRE(resp.second->getStatusCode() == drogon::k200OK);
 
   auto json = resp.second->getJsonObject();
-  REQUIRE((*json)["status"].asString() == "success");
+
   REQUIRE((*json)["token"].asString().length() > 0);
   REQUIRE((*json)["refresh_token"].asString().length() > 0);
 
@@ -41,7 +41,6 @@ DROGON_TEST(AuthenticationTest) {
   resp = client->sendRequest(req);
   REQUIRE(resp.second->getStatusCode() == drogon::k200OK);
   json = resp.second->getJsonObject();
-  REQUIRE((*json)["status"].asString() == "success");
 
   // Test login
   Json::Value login_json;
@@ -54,7 +53,7 @@ DROGON_TEST(AuthenticationTest) {
   resp = client->sendRequest(req);
   REQUIRE(resp.second->getStatusCode() == drogon::k200OK);
   json = resp.second->getJsonObject();
-  REQUIRE((*json)["status"].asString() == "success");
+
   REQUIRE((*json)["token"].asString().length() > 0);
   REQUIRE((*json)["refresh_token"].asString().length() > 0);
 
@@ -72,7 +71,7 @@ DROGON_TEST(AuthenticationTest) {
   resp = client->sendRequest(req);
   REQUIRE(resp.second->getStatusCode() == drogon::k200OK);
   json = resp.second->getJsonObject();
-  REQUIRE((*json)["status"].asString() == "success");
+
   REQUIRE((*json)["token"].asString().length() > 0);
 
   // Test logout
@@ -84,7 +83,6 @@ DROGON_TEST(AuthenticationTest) {
   resp = client->sendRequest(req);
   REQUIRE(resp.second->getStatusCode() == drogon::k200OK);
   json = resp.second->getJsonObject();
-  REQUIRE((*json)["status"].asString() == "success");
 
   helpers::cleanup_db();
 }

--- a/test_config-sample.json
+++ b/test_config-sample.json
@@ -4,7 +4,7 @@
       "name": "default",
       "rdbms": "postgresql",
       "host": "127.0.0.1",
-      "port": 5432,
+      "port": 5433,
       "dbname": "buyer_app_test",
       "user": "postgres",
       "passwd": "",
@@ -34,8 +34,8 @@
   },
   "custom_config": {
     "jwt_secret": "your_secure_random_production_secret",
-    "minio_endpoint": "http://localhost:9000",
+    "minio_endpoint": "http://localhost:9002",
     "minio_access_key": "minioadmin",
-    "minio_secret_key": "minioadmin"
+    "minio_secret_key": "mypassword"
   }
 }

--- a/utilities/conversion.hpp
+++ b/utilities/conversion.hpp
@@ -2,8 +2,12 @@
 #define CONVERSION_HPP
 
 #include <charconv>
+#include <concepts>
 #include <optional>
+#include <span>
+#include <string>
 #include <string_view>
+#include <vector>
 
 namespace convert {
 /* constexpr */ inline std::optional<int> string_to_int(std::string_view sv) {
@@ -13,6 +17,68 @@ namespace convert {
 
   return std::nullopt;
 };
+
+template <class T>
+concept Numeric = std::is_arithmetic_v<T>;
+
+template <Numeric T>
+inline std::optional<T> string_to_number(std::string_view sv) {
+  std::optional<T> value{{}};  // default init T
+  auto ret = std::from_chars(sv.data(), sv.data() + sv.size(), *value);
+  if (ret.ec == std::errc{} && ret.ptr == sv.data() + sv.size()) return value;
+  return std::nullopt;
+}
+
+// Array of strings to PostgreSQL array string
+// if empty returns "{}".
+inline std::string array_to_pgsql_array_string(
+    std::span<const std::string> tags) {
+  if (tags.empty()) {
+    return "{}";
+  }
+
+  std::string result = "{";
+  for (size_t i{0}; const auto& tag : tags) {
+    if (i > 0) {
+      result += ",";
+    }
+    result += tag;
+    ++i;
+  }
+  result += "}";
+
+  return result;
+}
+
+// PostgresSQL array string to std::vector<std::string>
+inline std::vector<std::string> pgsql_array_string_to_vector(
+    const std::string& array_str) {
+  std::vector<std::string> result;
+
+  if (array_str.size() < 2) {
+    return result;
+  }
+
+  // Parse PostgreSQL array format: {tag1,tag2,tag3}, remove {}
+  auto content = std::string_view(array_str.begin() + 1, array_str.end() - 1);
+
+  size_t count = std::count(content.begin(), content.end(), ',') + 1;
+  result.reserve(count);
+
+  size_t start = 0;
+  size_t end = content.find(',');
+  while (end != std::string::npos) {
+    result.emplace_back(content.substr(start, end - start));
+    start = end + 1;
+    end = content.find(',', start);
+  }
+  if (!content.substr(start).empty()) {
+    result.emplace_back(content.substr(start));  // Add the last substring
+  }
+
+  return result;
+}
+
 }  // namespace convert
 
 #endif

--- a/utilities/json_manipulation.hpp
+++ b/utilities/json_manipulation.hpp
@@ -1,0 +1,88 @@
+#ifndef JSON_MANIPULATION_HPP
+#define JSON_MANIPULATION_HPP
+
+#include <glaze/glaze.hpp>
+#include <optional>
+#include <string>
+
+namespace utilities {
+
+/**
+ * @brief Strict read JSON that requires all keys to be present and does not
+ * allow unknown keys.
+ * @tparam T The type to read into.
+ * @param value The value to read into. Of type T.
+ * @param buffer The input buffer containing the JSON data.
+ * @return glz::error_ctx if there is an error, otherwise returns the parsed
+ * value
+ */
+template <glz::read_supported<glz::JSON> T, glz::is_buffer Buffer>
+[[nodiscard]] inline glz::error_ctx strict_read_json(T &value,
+                                                     Buffer &&buffer) {
+  glz::context ctx{};
+  // .error_on_unknown_keys = true,
+  return read<glz::opts{.error_on_missing_keys = true}>(
+      value, std::forward<Buffer>(buffer), ctx);
+}
+
+/**
+ * @brief Strict read JSON that requires all keys to be present and does not
+ * allow unknown keys.
+ * @tparam T The type to read into.
+ * @param buffer The input buffer containing the JSON data.
+ * @return glz::expected containing the parsed value of type T or an error
+ * context
+ */
+template <glz::read_supported<glz::JSON> T, glz::is_buffer Buffer>
+[[nodiscard]] inline glz::expected<T, glz::error_ctx> strict_read_json(
+    Buffer &&buffer) {
+  T value{};
+  glz::context ctx{};
+  const glz::error_ctx ec = read<glz::opts{.error_on_missing_keys = true}>(
+      value, std::forward<Buffer>(buffer), ctx);
+  if (ec) {
+    return glz::unexpected<glz::error_ctx>(ec);
+  }
+  return value;
+}
+
+/**
+ * @brief Relaxed read JSON that allows unknown keys and missing keys.
+ * @tparam T The type to read into.
+ * @param value The value to read into. Of type T.
+ * @param buffer The input buffer containing the JSON data.
+ * @return glz::error_ctx if there is an error, otherwise returns the parsed
+ * value
+ */
+template <glz::read_supported<glz::JSON> T, glz::is_buffer Buffer>
+[[nodiscard]] inline glz::error_ctx relaxed_read_json(T &value,
+                                                      Buffer &&buffer) {
+  glz::context ctx{};
+  // .error_on_missing_keys = false (default)
+  return read<glz::opts{.error_on_unknown_keys = false}>(
+      value, std::forward<Buffer>(buffer), ctx);
+}
+
+/**
+ * @brief Relaxed read JSON that allows unknown keys and missing keys.
+ * @tparam T The type to read into.
+ * @param buffer The input buffer containing the JSON data.
+ * @return glz::expected containing the parsed value of type T or an error
+ * context
+ */
+template <glz::read_supported<glz::JSON> T, glz::is_buffer Buffer>
+[[nodiscard]] inline glz::expected<T, glz::error_ctx> relaxed_read_json(
+    Buffer &&buffer) {
+  T value{};
+  glz::context ctx{};
+  const glz::error_ctx ec = read<glz::opts{.error_on_unknown_keys = false}>(
+      value, std::forward<Buffer>(buffer), ctx);
+  if (ec) {
+    return glz::unexpected<glz::error_ctx>(ec);
+  }
+  return value;
+}
+
+}  // namespace utilities
+
+#endif  // JSON_MANIPULATION_HPP

--- a/utilities/validation.hpp
+++ b/utilities/validation.hpp
@@ -1,0 +1,37 @@
+#ifndef VALIDATION_HPP
+#define VALIDATION_HPP
+
+#include <regex>
+#include <string>
+
+namespace utilities {
+
+/**
+ * TODO: Test invalid email format
+ * To validate email addresses, we would need to conform to RFC 5322 format.
+ * Some alternatives include, relying on frontend that uses a fully defined
+ * parser e.g. https://github.com/jackbearheart/email-addresses
+ * or creating an RFC 5322 compliant Boost.parser/Lexy email address parser
+ * and using it. As we rely on verifying email with tokens, this may not be
+ * bad for normal application functionality. But a good validator prevent
+ * DDos with invalid emails and other issues.
+ * And no don't rely on Regex:
+ * https://stackoverflow.com/questions/201323/how-can-i-validate-an-email-address-using-a-regular-expression
+ *
+ **/
+// Quick and dirty RFC 5322 compliant email validator (basic)
+inline bool is_email_valid(const std::string& email) {
+  // Very basic regex for demonstration, not fully RFC compliant but covers most
+  // cases
+  // see https://stackoverflow.com/a/14075810 for a more detailed one
+  // but it is nots yet implementable in C++ ?
+  // Basic email regex: local@domain.tld (not fully RFC 5322 compliant)
+  const std::regex pattern(
+      R"(^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}$)");
+
+  return std::regex_match(email, pattern);
+}
+
+}  // namespace utilities
+
+#endif  // VALIDATION_HPP

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -27,6 +27,8 @@
       ]
     },
     "jwt-cpp",
+    "unordered-dense",
+    "glaze",
     {
       "name": "redis-plus-plus",
       "features": [


### PR DESCRIPTION
## Refactor to use Glaze for json serialization, parsing and validation

### **Commits:**
[deps + setup] - new Glaze dependency, bump to C++23, docker updates

+Verify docker container config and credentials
+ Bump to C++23

[refactor] - add utilities, port to Glaze for json, clean up auth code
+ add utilities for json manipulation, middlewares, validation and conversion


[refactor] - Use glaze for json manipulation, cleanup

+ search, users, s3_service, dashboard, orders


[refactor] - glaze refactor for connection_manager, notification, headers

+ notification_websocket, connection_manager, community, chats.hpp


[refactor] - glaze refactor & cleanup for chat, posts, offers, location controllers

+ fix failing tests

[docs] - Update with new docker instruction, new deps

+ Added volumes to gitignore